### PR TITLE
adding a quit menu entry

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1107,3 +1107,8 @@ void MainWindow::on_actionReset_settings_triggered()
         settings.clear();
     }
 }
+
+void MainWindow::on_actionQuit_triggered()
+{
+    close();
+}

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -186,6 +186,8 @@ private slots:
 
     void on_actionReset_settings_triggered();
 
+    void on_actionQuit_triggered();
+
 private:
     void refreshFlagspaces();
     bool doLock;

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -347,6 +347,7 @@ QToolButton { /* all types of tool button */
     <addaction name="separator"/>
     <addaction name="actionRun_Script"/>
     <addaction name="separator"/>
+    <addaction name="actionQuit"/>
    </widget>
    <widget class="QMenu" name="menuTools">
     <property name="title">
@@ -1085,6 +1086,14 @@ background: rgb(64, 64, 64);</string>
    </property>
    <property name="toolTip">
     <string>Reset settings</string>
+   </property>
+  </action>
+  <action name="actionQuit">
+   <property name="text">
+    <string>Quit</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Q</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
Without titlebar buttons, e. g. in i3, there was no easy way to quit.