### PR TITLE
thread cleanup

### DIFF
--- a/src/analthread.cpp
+++ b/src/analthread.cpp
@@ -1,18 +1,33 @@
 #include "analthread.h"
+#include "qrcore.h"
 #include <QDebug>
-#include "mainwindow.h"
 
-AnalThread::AnalThread(MainWindow *w, QWidget *parent) :
-    QThread(parent)
+AnalThread::AnalThread(QWidget *parent) :
+    QThread(parent),
+    core(nullptr),
+    level(2)
 {
-    // Radare core found in:
-    this->w = w;
-    //this->level = 2;
+}
+
+AnalThread::~AnalThread()
+{
+    if (isRunning()) {
+        quit();
+        wait();
+    }
+}
+
+void AnalThread::start(QRCore *core, int level)
+{
+    this->core = core;
+    this->level = level;
+
+    QThread::start();
 }
 
 // run() will be called when a thread starts
 void AnalThread::run()
 {
     //qDebug() << "Anal level: " << this->level;
-    this->w->core->analyze(this->level);
+    core->analyze(this->level);
 }

--- a/src/analthread.h
+++ b/src/analthread.h
@@ -3,19 +3,25 @@
 
 #include <QThread>
 
-class MainWindow;
+class QRCore;
 
 class AnalThread : public QThread
 {
         Q_OBJECT
 public:
-    explicit AnalThread(MainWindow *w, QWidget *parent = 0);
+    explicit AnalThread(QWidget *parent = 0);
+    ~AnalThread();
+
+    void start(QRCore *core, int level);
+
+protected:
     void run();
-    int level;
+
+    using QThread::start;
 
 private:
-
-    MainWindow *w;
+    QRCore *core;
+    int level;
 };
 
 #endif // ANALTHREAD_H

--- a/src/createnewdialog.cpp
+++ b/src/createnewdialog.cpp
@@ -11,7 +11,6 @@ createNewDialog::createNewDialog(QWidget *parent) :
     ui->setupUi(this);
     setWindowFlags(windowFlags() & (~Qt::WindowContextHelpButtonHint));
     w = new MainWindow(nullptr);
-    w->core = new QRCore ();
 }
 
 createNewDialog::~createNewDialog()

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -57,13 +57,14 @@ public:
     bool responsive;
 
     explicit MainWindow(QWidget *parent = 0);
+    ~MainWindow();
+
     void start_web_server();
     void closeEvent(QCloseEvent *event);
     void readSettings();
     void setFilename(QString fn);
     void setCore(QRCore *core);
     void seek(const QString& offset, const QString& name=NULL);
-    ~MainWindow();
     void updateFrames();
     void refreshFunctions();
     void refreshComments();
@@ -75,6 +76,8 @@ public:
     void adjustColumns(QTreeWidget *tw);
     void appendRow(QTreeWidget *tw, const QString &str, const QString &str2=NULL,
                           const QString &str3=NULL, const QString &str4=NULL, const QString &str5=NULL);
+
+    void setWebServerState(bool start);
 
 public slots:
 
@@ -186,6 +189,8 @@ private slots:
 
     void on_actionReset_settings_triggered();
 
+    void webserverThreadFinished();
+
 private:
     void refreshFlagspaces();
     bool doLock;
@@ -213,6 +218,7 @@ private:
     QLineEdit        *gotoEntry;
     SdbDock          *sdbDock;
     QAction          *sidebar_action;
+    WebServerThread webserverThread;
 };
 
 #endif // MAINWINDOW_H

--- a/src/optionsdialog.cpp
+++ b/src/optionsdialog.cpp
@@ -8,7 +8,8 @@
 
 OptionsDialog::OptionsDialog(QWidget *parent):
     QDialog(parent),
-    ui(new Ui::OptionsDialog)
+    ui(new Ui::OptionsDialog),
+    analThread(this)
 {
     this->core = new QRCore();
     this->anal_level = 0;
@@ -39,6 +40,8 @@ OptionsDialog::OptionsDialog(QWidget *parent):
 
     // Add this so the dialog resizes when widgets are shown/hidden
     //this->layout()->setSizeConstraint(QLayout::SetFixedSize);
+
+    connect(&analThread, SIGNAL(finished()), this, SLOT(anal_finished()));
 }
 
 OptionsDialog::~OptionsDialog()
@@ -169,18 +172,14 @@ void OptionsDialog::on_okButton_clicked()
     ui->statusLabel->setText("Analysis in progress");
 
     // Threads stuff
-    // create an instance of MyThread
-    this->analThread = new AnalThread(w);
-
     // connect signal/slot
-    connect(analThread, SIGNAL(finished()), this, SLOT(anal_finished()));
-    //analThread->level = anal_level;
+
+    int level = 0;
     if (anal_level == true) {
-        analThread->level = ui->analSlider->value();
-    } else {
-        analThread->level = 0;
+        level = ui->analSlider->value();
     }
-    analThread->start();
+
+    analThread.start(core, level);
 }
 
 void OptionsDialog::anal_finished()

--- a/src/optionsdialog.h
+++ b/src/optionsdialog.h
@@ -43,7 +43,7 @@ private:
     QString filename;
     QString shortfn;
     Ui::OptionsDialog *ui;
-    AnalThread *analThread;
+    AnalThread analThread;
     MainWindow *w;
 };
 

--- a/src/webserverthread.cpp
+++ b/src/webserverthread.cpp
@@ -1,14 +1,78 @@
 #include "webserverthread.h"
+#include "qrcore.h"
+#include <cassert>
 
-WebServerThread::WebServerThread(QObject *parent) :
-    QThread(parent)
+WebServerThread::WebServerThread(QRCore *core, QObject *parent) :
+    QThread(parent),
+    core(core),
+    started(false)
 {
     // MEOW
 }
 
+WebServerThread::~WebServerThread()
+{
+    if (isRunning()) {
+        quit();
+        wait();
+    }
+}
+
+void WebServerThread::startServer()
+{
+    assert(nullptr != core);
+
+    if (!isRunning() && !started) {
+        QThread::start();
+    }
+}
+
+void WebServerThread::stopServer()
+{
+    assert(nullptr != core);
+
+    if (!isRunning() && started)
+    {
+        QThread::start();
+    }
+}
+
+bool WebServerThread::isStarted() const
+{
+    QMutexLocker locker(&mutex);
+    return started;
+}
+
 void WebServerThread::run() {
-    if (core == NULL)
+    QMutexLocker locker(&mutex);
+
+    if (core == nullptr)
         return;
     //eprintf ("Starting webserver!");
-    core->cmd ("=h");
+
+    toggleWebServer();
+}
+
+void WebServerThread::toggleWebServer()
+{
+    // access already locked
+
+    // see libr/core/rtr.c
+    // "=h", " port", "listen for http connections (r2 -qc=H /bin/ls)",
+    // "=h-", "", "stop background webserver",
+    // "=h*", "", "restart current webserver",
+    // "=h&", " port", "start http server in background)",
+
+    if (started) {
+        // after this the only reaction to this commands is:
+        // sandbox: connect disabled
+        // and the webserver is still running
+        // TODO: find out why
+        core->cmd("=h-");
+    } else {
+        core->cmd("=h&");
+    }
+
+    // cmd has no usefull return value for this commands, so just toogle the state
+    started = !started;
 }

--- a/src/webserverthread.h
+++ b/src/webserverthread.h
@@ -2,20 +2,32 @@
 #define WEBSERVERTHREAD_H
 
 #include <QThread>
-#include "qrcore.h"
+#include <QMutex>
+
+class QRCore;
 
 class WebServerThread : public QThread
 {
     Q_OBJECT
 public:
-    QRCore *core;
-    explicit WebServerThread(QObject *parent = 0);
 
-signals:
+    explicit WebServerThread(QRCore *core, QObject *parent = 0);
+    ~WebServerThread();
 
-public slots:
+    void startServer();
+    void stopServer();
+
+    bool isStarted() const;
+
 private:
     void run();
+    using QThread::start;
+
+    void toggleWebServer();
+
+    mutable QMutex mutex;
+    QRCore *core;
+    bool   started;
 };
 
 #endif // WEBSERVERTHREAD_H

--- a/src/widgets/sidebar.cpp
+++ b/src/widgets/sidebar.cpp
@@ -5,14 +5,13 @@
 
 #include "mainwindow.h"
 
-SideBar::SideBar(MainWindow *main, QWidget *parent) :
-    QWidget(parent),
-    ui(new Ui::SideBar)
+SideBar::SideBar(MainWindow *main) :
+    QWidget(main),
+    ui(new Ui::SideBar),
+    // Radare core found in:
+    main(main)
 {
     ui->setupUi(this);
-
-    // Radare core found in:
-    this->main = main;
 
     QSettings settings("iaito", "iaito");
     if (settings.value("responsive").toBool()) {
@@ -44,24 +43,7 @@ void SideBar::on_consoleButton_clicked()
 
 void SideBar::on_webServerButton_clicked()
 {
-    static WebServerThread thread;
-    if (ui->webServerButton->isChecked()) {
-        // Start web server
-        thread.core = this->main->core;
-        thread.start();
-        QThread::sleep (1);
-        if (this->main->core->core->http_up==R_FALSE) {
-            eprintf ("FAILED TO LAUNCH\n");
-        }
-        // Open web interface on default browser
-        //QString link = "http://localhost:9090/";
-        //QDesktopServices::openUrl(QUrl(link));
-    } else {
-        this->main->core->core->http_up= R_FALSE;
-        // call something to kill the webserver!!
-        thread.exit(0);
-        // Stop web server
-    }
+    main->setWebServerState(ui->webServerButton->isChecked());
 }
 
 void SideBar::on_lockButton_clicked()

--- a/src/widgets/sidebar.h
+++ b/src/widgets/sidebar.h
@@ -14,7 +14,7 @@ class SideBar : public QWidget
     Q_OBJECT
 
 public:
-    explicit SideBar(MainWindow *main, QWidget *parent = 0);
+    explicit SideBar(MainWindow *main);
     ~SideBar();
 
 public slots:
@@ -43,7 +43,7 @@ private slots:
 
 private:
     Ui::SideBar *ui;
-    MainWindow      *main;
+    MainWindow  *main;
 };
 
 #endif // SIDEBAR_H


### PR DESCRIPTION
Some cleanup and fixes for crashes rooted in the different static QThreads.

TBH I think the WebServerThread should be removed and replaced by some kind of manager class which calls a generic non-blocking command executor class.