### PR TITLE
Compile on Travis CI and upload AppImage for each build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ script:
   - # sudo make INSTALL_ROOT=appdir install ; sudo chown -R $USER appdir ; find appdir/
   - mkdir -p appdir/usr/bin
   - cp iaito appdir/usr/bin
-  - touch appdir/iaito.png # FIXME
+  - cp ../src/img/logo-small.png appdir/iaito.png
   - cp ../src/iaito.desktop appdir/
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+language: cpp
+compiler: gcc
+sudo: require
+dist: trusty
+
+before_install:
+    - sudo add-apt-repository ppa:beineri/opt-qt58-trusty -y
+    - sudo apt-get update -qq
+    
+install: 
+    - sudo apt-get -y install qt58base
+    - source /opt/qt58/bin/qt58-env.sh
+
+script:
+  - git submodule init ; git submodule update
+  - cd radare2
+  - sys/install.sh
+  - cd ..
+  - mkdir build ; cd build
+  - qmake PREFIX=/usr ../src
+  - make -j4
+  - sudo make INSTALL_ROOT=appdir install ; sudo chown -R $USER appdir ; find appdir/
+
+after_success:
+  - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" 
+  - chmod a+x linuxdeployqt*.AppImage
+  - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
+  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs
+  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -appimage
+  - find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
+  - curl --upload-file ./iaito*.AppImage https://transfer.sh/iaito-git.$(git rev-parse --short HEAD)-x86_64.AppImage

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,12 @@ sudo: require
 dist: trusty
 
 before_install:
-    - sudo add-apt-repository ppa:beineri/opt-qt58-trusty -y
+    - sudo add-apt-repository ppa:beineri/opt-qt532-trusty -y
     - sudo apt-get update -qq
     
 install: 
-    - sudo apt-get -y install qt58base
-    - source /opt/qt58/bin/qt58-env.sh
+    - sudo apt-get -y install qt53base qt53webkit-examples
+    - source /opt/qt5*/bin/qt5*-env.sh
 
 script:
   - git submodule init ; git submodule update

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,11 @@ script:
   - # make install does not work, so do it by hand
   - # sudo make INSTALL_ROOT=appdir install ; sudo chown -R $USER appdir ; find appdir/
   - mkdir -p appdir/usr/bin
+  - mkdir -p appdir/usr/share/applications
   - cp iaito appdir/usr/bin
   - cp ../src/img/logo-small.png appdir/iaito.png
   - cp ../src/iaito.desktop appdir/
+  - cp ../src/iaito.desktop appdir/usr/share/applications/
 
 after_success:
   - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" 
@@ -33,4 +35,4 @@ after_success:
   - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs
   - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -appimage
   - find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
-  - curl --upload-file ./iaito*.AppImage https://transfer.sh/iaito-git.$(git rev-parse --short HEAD)-x86_64.AppImage
+  - curl --upload-file ./Iai*.AppImage https://transfer.sh/Iaito-git.$(git rev-parse --short HEAD)-x86_64.AppImage

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,9 @@ after_success:
   - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" 
   - chmod a+x linuxdeployqt*.AppImage
   - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
-  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs
-  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -appimage
+  - ./linuxdeployqt*.AppImage --appimage-extract
+  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs -verbose=2
+  - ./squashfs-root/usr/bin/patchelf --set-rpath '$ORIGIN/../../lib' ./appdir/usr/plugins/platforms/libqxcb.so # linuxdeployqt bug?
+  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -appimage -verbose=2
   - find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
   - curl --upload-file ./Iai*.AppImage https://transfer.sh/Iaito-git.$(git rev-parse --short HEAD)-x86_64.AppImage

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,12 @@ script:
   - mkdir build ; cd build
   - qmake PREFIX=/usr ../src
   - make -j4
-  - sudo make INSTALL_ROOT=appdir install ; sudo chown -R $USER appdir ; find appdir/
+  - # make install does not work, so do it by hand
+  - # sudo make INSTALL_ROOT=appdir install ; sudo chown -R $USER appdir ; find appdir/
+  - mkdir -p appdir/usr/bin
+  - cp iaito appdir/usr/bin
+  - touch appdir/iaito.png # FIXME
+  - cp ../src/iaito.desktop appdir/
 
 after_success:
   - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" 

--- a/src/iaito.desktop
+++ b/src/iaito.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Type=Application
-Name=Iaito
+Name=Iaitō
 Exec=iaito
 Icon=iaito
 Categories=Development;

--- a/src/iaito.desktop
+++ b/src/iaito.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Type=Application
+Name=Iaito
+Exec=iaito
+Icon=iaito
+Categories=Development;


### PR DESCRIPTION
This PR, when merged, will compile this application on [Travis CI](https://travis-ci.org/) upon each `git push`, and upload an [AppImage](http://appimage.org/) to a temporary download URL on transfer.sh (available for 14 days). The download URL is toward the end of each Travis CI build log of each build (see below for how to set up automatic uploading to your GitHub Releases page).

For this to work, you need to enable Travis CI for your repository as [described here](https://travis-ci.org/getting_started) __prior to merging this__, if you haven't already done so.

Providing an [AppImage](http://appimage.org/) would have, among others, these advantages:
- Works for most Linux distributions (including Ubuntu, Fedora, openSUSE, CentOS, elementaryOS, Linux Mint, and others)
- One app = one file = super simple for users: just download one AppImage file, [make it executable](http://discourse.appimage.org/t/how-to-make-an-appimage-executable/80), and run
- No unpacking or installation necessary
- No root needed
- No system libraries changed
- Just one format for all major distributions
- Works out of the box, no installation of runtimes needed (unlike Snap and Flatpak)
- Optional desktop integration with `appimaged`
- Optional binary delta updates, e.g., for continuous builds (only download the binary diff) using AppImageUpdate
- Can optionally GPG2-sign your AppImages (inside the file)
- Works on Live ISOs
- Can use the same AppImages when dual-booting multiple distributions

[Here is an overview](https://github.com/probonopd/AppImageKit/wiki/AppImages) of projects that are already distributing upstream-provided, official AppImages.

__Please note:__ Instead of storing AppImage builds temporarily for 14 days each on transfer.sh, you could use GitHub Releases to store the binaries permanently. This way, they would be visible on the Releases page of your project. This is what I recommend. See https://docs.travis-ci.com/user/deployment/releases/. If you want to do this for continuous builds, also see https://github.com/probonopd/uploadtool.

If you would like to see only one entry for the Pull Request in your project's history, then please enable [this GitHub functionality](https://help.github.com/articles/configuring-commit-squashing-for-pull-requests/) on your repo. It allows you to squash (combine) the commits when merging.

If you have questions, AppImage developers are on #AppImage on irc.freenode.net.