### PR TITLE
Remove linuxdeployqt workaround

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,7 @@ after_success:
   - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" 
   - chmod a+x linuxdeployqt*.AppImage
   - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
-  # - ./linuxdeployqt*.AppImage --appimage-extract
   - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs -verbose=2
-  # - ./squashfs-root/usr/bin/patchelf --set-rpath '$ORIGIN/../../lib' ./appdir/usr/plugins/platforms/libqxcb.so # linuxdeployqt bug?
   - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -appimage -verbose=2
   - find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
   - curl --upload-file ./Iai*.AppImage https://transfer.sh/Iaito-git.$(git rev-parse --short HEAD)-x86_64.AppImage

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,9 @@ after_success:
   - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" 
   - chmod a+x linuxdeployqt*.AppImage
   - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
-  - ./linuxdeployqt*.AppImage --appimage-extract
+  # - ./linuxdeployqt*.AppImage --appimage-extract
   - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs -verbose=2
-  - ./squashfs-root/usr/bin/patchelf --set-rpath '$ORIGIN/../../lib' ./appdir/usr/plugins/platforms/libqxcb.so # linuxdeployqt bug?
+  # - ./squashfs-root/usr/bin/patchelf --set-rpath '$ORIGIN/../../lib' ./appdir/usr/plugins/platforms/libqxcb.so # linuxdeployqt bug?
   - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -appimage -verbose=2
   - find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
   - curl --upload-file ./Iai*.AppImage https://transfer.sh/Iaito-git.$(git rev-parse --short HEAD)-x86_64.AppImage


### PR DESCRIPTION
Remove linuxdeployqt workaround which is no longer necessary since https://github.com/probonopd/linuxdeployqt/commit/bace185665b3738cfc875a04edfa16998a06997c