### PR TITLE
Show Travis CI build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Iaitō
+# Iaitō [![Build Status](https://travis-ci.org/hteso/iaito.svg?branch=master)](https://travis-ci.org/hteso/iaito)
 
 > The GUI that ~~radare2~~ humans deserve
 


### PR DESCRIPTION
The button is clickable and will take you to the latest Travis CI build log, where you will also see the AppImage download URL.