### PR TITLE
Fix sidebar crash

### DIFF
--- a/src/qrcore.cpp
+++ b/src/qrcore.cpp
@@ -511,14 +511,14 @@ void QRCore::setDefaultCPU() {
 
 QString QRCore::assemble(const QString &code) {
     RAsmCode *ac = r_asm_massemble (core->assembler, code.toUtf8().constData());
-    QString hex(nullptr != ac ? ac->buf_hex : "");
+    QString hex(ac != nullptr ? ac->buf_hex : "");
     r_asm_code_free (ac);
     return hex;
 }
 
 QString QRCore::disassemble(const QString &hex) {
     RAsmCode *ac = r_asm_mdisassemble_hexstr(core->assembler, hex.toUtf8().constData());
-    QString code = QString (nullptr != ac ? ac->buf_asm : "");
+    QString code = QString (ac != nullptr ? ac->buf_asm : "");
     r_asm_code_free (ac);
     return code;
 }
@@ -540,7 +540,7 @@ int QRCore::get_size()
 {
     RBinObject *obj = r_bin_get_object(core->bin);
     //return obj->size;
-    return nullptr != obj ? obj->obj_size : 0;
+    return obj != nullptr? obj->obj_size : 0;
 }
 
 ulong QRCore::get_baddr()

--- a/src/qrcore.cpp
+++ b/src/qrcore.cpp
@@ -511,14 +511,14 @@ void QRCore::setDefaultCPU() {
 
 QString QRCore::assemble(const QString &code) {
     RAsmCode *ac = r_asm_massemble (core->assembler, code.toUtf8().constData());
-    QString hex = QString(ac->buf_hex);
+    QString hex(nullptr != ac ? ac->buf_hex : "");
     r_asm_code_free (ac);
     return hex;
 }
 
 QString QRCore::disassemble(const QString &hex) {
     RAsmCode *ac = r_asm_mdisassemble_hexstr(core->assembler, hex.toUtf8().constData());
-    QString code = QString (ac->buf_asm);
+    QString code = QString (nullptr != ac ? ac->buf_asm : "");
     r_asm_code_free (ac);
     return code;
 }
@@ -540,7 +540,7 @@ int QRCore::get_size()
 {
     RBinObject *obj = r_bin_get_object(core->bin);
     //return obj->size;
-    return obj->obj_size;
+    return nullptr != obj ? obj->obj_size : 0;
 }
 
 ulong QRCore::get_baddr()

--- a/src/qrcore.cpp
+++ b/src/qrcore.cpp
@@ -540,7 +540,7 @@ int QRCore::get_size()
 {
     RBinObject *obj = r_bin_get_object(core->bin);
     //return obj->size;
-    return obj != nullptr? obj->obj_size : 0;
+    return obj != nullptr ? obj->obj_size : 0;
 }
 
 ulong QRCore::get_baddr()

--- a/src/widgets/sidebar.cpp
+++ b/src/widgets/sidebar.cpp
@@ -89,7 +89,7 @@ void SideBar::on_asm2hex_clicked()
 
 void SideBar::on_hex2asm_clicked()
 {
-    ui->asmInput->setPlainText(main->core->assemble(ui->hexInput->toPlainText()));
+    ui->asmInput->setPlainText(main->core->disassemble(ui->hexInput->toPlainText()));
 }
 
 void SideBar::on_respButton_toggled(bool checked)


### PR DESCRIPTION
Actually fixes crashes on invalid code or hex input in the QRCore assemble and disassemble functions.

Since hex2asm wasn't working I changed it to QRCore::disassemble and it seems to work now. Is this correct?

Another question:
RBinObject->obj_size is of type ut64 is it safe to to convert this to int?