### PR TITLE
Fix webview restriction

### DIFF
--- a/src/widgets/memwidget/memorywidget.cpp
+++ b/src/widgets/memwidget/memorywidget.cpp
@@ -69,6 +69,11 @@ MemoryWidget::MemoryWidget(MainWindow *main, QWidget *parent) :
     ui->graphWebView->page()->mainFrame()->setScrollBarPolicy(Qt::Vertical, Qt::ScrollBarAlwaysOff);
     ui->graphWebView->page()->mainFrame()->setScrollBarPolicy(Qt::Horizontal, Qt::ScrollBarAlwaysOff);
 
+    // Allows the local resources (qrc://) to access http content
+    if (!ui->graphWebView->settings()->testAttribute(QWebSettings::LocalContentCanAccessRemoteUrls)) {
+        ui->graphWebView->settings()->setAttribute(QWebSettings::LocalContentCanAccessRemoteUrls, true);
+    }
+
     // Debug console
     QWebSettings::globalSettings()->setAttribute(QWebSettings::DeveloperExtrasEnabled, true);
 

--- a/src/widgets/memwidget/memorywidget.cpp
+++ b/src/widgets/memwidget/memorywidget.cpp
@@ -16,8 +16,8 @@
 #include <QFont>
 #include <QUrl>
 
-MemoryWidget::MemoryWidget(MainWindow *main, QWidget *parent) :
-    QDockWidget(parent),
+MemoryWidget::MemoryWidget(MainWindow *main) :
+    QDockWidget(main),
     ui(new Ui::MemoryWidget)
 {
     ui->setupUi(this);

--- a/src/widgets/memwidget/memorywidget.h
+++ b/src/widgets/memwidget/memorywidget.h
@@ -27,7 +27,7 @@ class MemoryWidget : public QDockWidget
     Q_OBJECT
 
 public:
-    explicit MemoryWidget(MainWindow *main, QWidget *parent = 0);
+    explicit MemoryWidget(MainWindow *main);
     ~MemoryWidget();
 
     MainWindow       *main;


### PR DESCRIPTION
Investigating why I'm unable to see the graph I found the following error message in the inspector. 
![qrc_http](https://cloud.githubusercontent.com/assets/159463/24837670/aa801cf6-1d39-11e7-8797-48ab2d1fce46.png)
The doc [QWebSecurityOrigin](http://doc.qt.io/archives/qt-5.5/qwebsecurityorigin.html#detailsl) states that this is expected behavior (not sure if this changed from Qt 5.3 upwards. I'm currently using 5.8). 

Additional the `parent` parameter was never used and as such could be removed.
 