### PR TITLE
Fix issue #103: refresh disam on CTRL+r

### DIFF
--- a/src/widgets/memwidget/memorywidget.cpp
+++ b/src/widgets/memwidget/memorywidget.cpp
@@ -166,6 +166,11 @@ MemoryWidget::MemoryWidget(MainWindow *main, QWidget *parent) :
     connect(back_shortcut, SIGNAL(activated()), this, SLOT(seek_back()));
     back_shortcut->setContext(Qt::WidgetShortcut);
 
+    // CTRL + R to refresh the disasm
+    QShortcut* refresh_shortcut = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_R), ui->disasTextEdit_2);
+    connect(refresh_shortcut, SIGNAL(activated()), this, SLOT(refreshDisasm()));
+    refresh_shortcut->setContext(Qt::WidgetShortcut);
+
     // Control Disasm and Hex scroll to add more contents
     connect(this->disasTextEdit->verticalScrollBar(), SIGNAL(valueChanged(int)), this, SLOT(disasmScrolled()));
     connect(this->hexASCIIText->verticalScrollBar(), SIGNAL(valueChanged(int)), this, SLOT(hexScrolled()));
@@ -444,8 +449,8 @@ void MemoryWidget::disasmScrolled()
     connect(this->disasTextEdit->verticalScrollBar(), SIGNAL(valueChanged(int)), this, SLOT(disasmScrolled()));
 }
 
-void MemoryWidget::refreshDisasm(QString off = "") {
-
+void MemoryWidget::refreshDisasm(const QString &offset)
+{
     // we must store those ranges somewhere, to handle scroll
     ut64 addr = this->main->core->core->offset;
     int length = this->main->core->core->num->value;
@@ -454,8 +459,8 @@ void MemoryWidget::refreshDisasm(QString off = "") {
     disconnect(this->disasTextEdit->verticalScrollBar(), SIGNAL(valueChanged(int)), this, SLOT(disasmScrolled()));
 
     // Get disas at offset
-    if (off != "") {
-        this->main->core->cmd("s " + off);
+    if (!offset.isEmpty()) {
+        this->main->core->cmd("s " + offset);
     } else {
         // Get current offset
         QTextCursor tc = this->disasTextEdit->textCursor();

--- a/src/widgets/memwidget/memorywidget.h
+++ b/src/widgets/memwidget/memorywidget.h
@@ -56,7 +56,7 @@ public slots:
 
     void replaceTextDisasm(QString txt);
 
-    void refreshDisasm(QString off);
+    void refreshDisasm(const QString &offset = QString());
 
     void refreshHexdump(QString where=0);
 


### PR DESCRIPTION
Adds a QShortcut to refresh the disasm editor. To make this work the
default parameter of the slot MemoryWidget::refreshDisasm() had to be
defined in the header/at declaration point, else the connect failed.

Known issue: the spacing in the text edit gets changed after the first refresh. Maybe the initial disam isn't formatted with the setting set in QRCore? 