### PR TITLE
Add QRCore::cmdj, Use iij to fix crash when import name contains spaces

### DIFF
--- a/src/qrcore.cpp
+++ b/src/qrcore.cpp
@@ -1,6 +1,8 @@
 #include "qrcore.h"
 #include "sdb.h"
 
+#include <QRegularExpression>
+
 #define DB this->db
 
 RCoreLocked::RCoreLocked(RCore *core)
@@ -457,17 +459,15 @@ QList<QString> QRCore::getList(const QString &type, const QString &subtype)
             QStringList lines = this->cmd("ii").split("\n");
             foreach (QString line, lines)
             {
-                QStringList tmp = line.split(" ");
-                if (tmp.length() > 2)
-                {
-                    QString final;
-                    foreach (QString field, tmp)
-                    {
-                        QString value = field.split("=")[1];
-                        final.append(value + ",");
-                    }
-                    ret << final;
-                }
+                QRegularExpression re("^ordinal=([^\\ ]*) plt=([^\\ ]*) bind=([^\\ ]*) type=([^\\ ]*) name=(.*)$");
+                QRegularExpressionMatch match = re.match(line);
+
+                if(!match.hasMatch())
+                    continue;
+
+                QString final = QString("%1,%2,%3,%4,%5,").arg(match.captured(1), match.captured(2),
+                                                     match.captured(3), match.captured(4), match.captured(5));
+                ret << final;
             }
         }
         else if (subtype == "entrypoints")

--- a/src/qrcore.cpp
+++ b/src/qrcore.cpp
@@ -1,7 +1,8 @@
 #include "qrcore.h"
 #include "sdb.h"
 
-#include <QRegularExpression>
+#include <QJsonArray>
+#include <QJsonObject>
 
 #define DB this->db
 
@@ -215,6 +216,16 @@ QString QRCore::cmd(const QString &str)
     //r_mem_free was added in https://github.com/radare/radare2/commit/cd28744049492dc8ac25a1f2b3ba0e42f0e9ce93
     r_mem_free(res);
     return o;
+}
+
+QJsonDocument QRCore::cmdj(const QString &str)
+{
+    CORE_LOCK();
+    QByteArray cmd = str.toUtf8();
+    char *res = r_core_cmd_str(this->core_, cmd.constData());
+    QJsonDocument doc = res ? QJsonDocument::fromJson(QByteArray(res)) : QJsonDocument();
+    r_mem_free(res);
+    return doc;
 }
 
 bool QRCore::loadFile(QString path, uint64_t loadaddr = 0LL, uint64_t mapaddr = 0LL, bool rw = false, int va = 0, int bits = 0, int idx, bool loadbin)
@@ -455,18 +466,22 @@ QList<QString> QRCore::getList(const QString &type, const QString &subtype)
         }
         else if (subtype == "imports")
         {
+            QJsonArray importsArray = cmdj("iij").array();
 
-            QStringList lines = this->cmd("ii").split("\n");
-            foreach (QString line, lines)
+            foreach(QJsonValue value, importsArray)
             {
-                QRegularExpression re("^ordinal=([^\\ ]*) plt=([^\\ ]*) bind=([^\\ ]*) type=([^\\ ]*) name=(.*)$");
-                QRegularExpressionMatch match = re.match(line);
+                QJsonObject importObject = value.toObject();
+                unsigned long plt = (unsigned long)importObject["plt"].toVariant().toULongLong();
+                int ordinal = importObject["ordinal"].toInt();
 
-                if(!match.hasMatch())
-                    continue;
+                QString final = QString("%1,%2,%3,%4,%5,").arg(
+                            QString::asprintf("%#o", ordinal),
+                            QString::asprintf("%#010lx", plt),
+                            importObject["bind"].toString(),
+                            importObject["type"].toString(),
+                            importObject["name"].toString());
 
-                QString final = QString("%1,%2,%3,%4,%5,").arg(match.captured(1), match.captured(2),
-                                                     match.captured(3), match.captured(4), match.captured(5));
+
                 ret << final;
             }
         }

--- a/src/qrcore.h
+++ b/src/qrcore.h
@@ -6,6 +6,7 @@
 #include <QObject>
 #include <QStringList>
 #include <QMessageBox>
+#include <QJsonDocument>
 
 //Workaround for compile errors on Windows
 #ifdef _WIN32
@@ -58,6 +59,7 @@ public:
     int fcnBasicBlockCount(ut64 addr);
     int fcnEndBbs(QString addr);
     QString cmd(const QString &str);
+    QJsonDocument cmdj(const QString &str);
     void renameFunction(QString prev_name, QString new_name);
     void setComment(QString addr, QString cmt);
     void delComment(ut64 addr);


### PR DESCRIPTION
Sometimes, the `ii` command returns a name with spaces, like this:
```ordinal=003 plt=0x1000036c8 bind=NONE type=FUNC name=sym.imp.print (__Array P)```
This made iaito crash before.