### PR TITLE
Add custom astylerc

### DIFF
--- a/src/iaito.astylerc
+++ b/src/iaito.astylerc
@@ -1,0 +1,13 @@
+--style=allman
+--convert-tabs
+--align-pointer=name
+--align-reference=name
+--indent=spaces
+--indent-namespaces
+--indent-col1-comments
+--pad-oper
+--pad-header
+--unpad-paren
+--keep-one-line-blocks
+--close-templates
+

--- a/src/iaito.pro
+++ b/src/iaito.pro
@@ -126,6 +126,9 @@ FORMS    += \
 RESOURCES += \
     resources.qrc
 
+DISTFILES += iaito.astylerc
+
+
 include(lib_radare2.pri)
 
 


### PR DESCRIPTION
Adds iaito.astylerc based on CONTRIBUTING.md.

Added to DISTFILES so it will be used by QtCreator when [`Use file defined in project files`](http://doc.qt.io/qtcreator/creator-beautifier.html)  is enabled. (Note: This will not auto format the code)