### PR TITLE
Use qmake pkgconfig feature

### DIFF
--- a/src/lib_radare2.pri
+++ b/src/lib_radare2.pri
@@ -8,48 +8,39 @@ win32 {
     } else {
         LIBS += -L"$$PWD/../iaito_win32/radare2/lib64"
     }
+
+    LIBS += \
+        -lr_core \
+        -lr_config \
+        -lr_cons \
+        -lr_io \
+        -lr_util \
+        -lr_flag \
+        -lr_asm \
+        -lr_debug \
+        -lr_hash \
+        -lr_bin \
+        -lr_lang \
+        -lr_io \
+        -lr_anal \
+        -lr_parse \
+        -lr_bp \
+        -lr_egg \
+        -lr_reg \
+        -lr_search \
+        -lr_syscall \
+        -lr_socket \
+        -lr_fs \
+        -lr_magic \
+        -lr_crypto
 } else {
-    # check if r2 is available
-    system(r2 > /dev/null 2>&1) {
-
-        # see https://github.com/hteso/iaito/pull/5#issuecomment-290433796
-        RADARE2_INCLUDE_PATH = $$system(r2 -H | grep INCDIR | sed 's/[^=]*=//')
-        RADARE2_LIB_PATH = $$system(r2 -H | grep LIBDIR | sed 's/[^=]*=//')
-
-        !isEmpty(RADARE2_INCLUDE_PATH) {
-            INCLUDEPATH *= $$RADARE2_INCLUDE_PATH
-            LIBS *= -L$$RADARE2_LIB_PATH
-        } else {
-            error("sorry could not find radare2 lib")
-        }
-    } else {
-        error("r2 not found/in path")
+    R2_USER_PKGCONFIG = $$(HOME)/bin/prefix/radare2/lib/pkgconfig
+    exists($$R2_USER_PKGCONFIG) {
+        # caution: may not work for cross compilations
+        QMAKE_PKG_CONFIG = PKG_CONFIG_PATH=$$R2_USER_PKGCONFIG pkg-config
     }
+
+    CONFIG += link_pkgconfig
+    PKGCONFIG += r_core
 }
-
-
-LIBS += \
-    -lr_core \
-    -lr_config \
-    -lr_cons \
-    -lr_io \
-    -lr_util \
-    -lr_flag \
-    -lr_asm \
-    -lr_debug \
-    -lr_hash \
-    -lr_bin \
-    -lr_lang \
-    -lr_io \
-    -lr_anal \
-    -lr_parse \
-    -lr_bp \
-    -lr_egg \
-    -lr_reg \
-    -lr_search \
-    -lr_syscall \
-    -lr_socket \
-    -lr_fs \
-    -lr_magic \
-    -lr_crypto
 

--- a/src/lib_radare2.pri
+++ b/src/lib_radare2.pri
@@ -3,7 +3,7 @@ win32 {
     DEFINES += _CRT_SECURE_NO_WARNINGS
     INCLUDEPATH += "$$PWD/../iaito_win32/include"
     INCLUDEPATH += "$$PWD/../iaito_win32/radare2/include/libr"
-    !contains(QMAKE_HOST.arch, x86_64) {
+    !contains(QT_ARCH, x86_64) {
         LIBS += -L"$$PWD/../iaito_win32/radare2/lib32"
     } else {
         LIBS += -L"$$PWD/../iaito_win32/radare2/lib64"


### PR DESCRIPTION
- Use pkgconfig for non windows builds (with a rather undocumented qmake feature, see mkspec/features/link_pkgconfig.prf)
- win: Use QT_ARCH instead of QMAKE_HOST.arch. Makes it possible to switch the target arch by the used Qt lib/kit (QMAKE_TARGET.arch is not defined in Qt5, see https://bugreports.qt.io/browse/QTBUG-30263)

Should fix #143

@mrexodia Can you please test the change on windows? I'll merge it then.