### PR TITLE
Refactor FlagsWidget to use QAbstractItemModel (and some other details)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,7 +36,7 @@ link_directories(${RADARE2_LIBRARY_DIRS})
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
         OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    add_definitions(-Wall)
+    add_definitions(-Wall -Wextra)
 endif()
 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,19 +26,12 @@ if(WIN32)
     endif()
 
     set(RADARE2_INCLUDE_DIRS "${IAITO_WIN32_DIR}/radare2/include/libr" "${IAITO_WIN32_DIR}/include")
-
-    find_package(Radare2 REQUIRED)
-else()
-    # support sys/user.sh install
-    list(APPEND CMAKE_PREFIX_PATH "$ENV{HOME}/bin/prefix/radare2")
-
-    find_package(PkgConfig REQUIRED)
-    pkg_search_module(RADARE2 REQUIRED r_core)
-
-    link_directories(${RADARE2_LIBRARY_DIRS})
 endif()
 
+
+find_package(Radare2 REQUIRED)
 include_directories(${RADARE2_INCLUDE_DIRS})
+link_directories(${RADARE2_LIBRARY_DIRS})
 
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU"

--- a/src/cmake/FindRadare2.cmake
+++ b/src/cmake/FindRadare2.cmake
@@ -1,57 +1,75 @@
 # - Find Radare2 (libr)
 #
 #  RADARE2_FOUND          - True if libr has been found.
-#  RADARE2_INCLUDE_DIRS   - libr Include Directory
+#  RADARE2_INCLUDE_DIRS   - libr include directory
 #  RADARE2_LIBRARIES      - List of libraries when using libr.
+#  RADARE2_LIBRARY_DIRS   - libr library directories
+#
+#  If libr was found using find_library and not pkg-config, the following variables will also be set:
 #  RADARE2_LIBRARY_<name> - Path to library r_<name>
 
-find_path(RADARE2_INCLUDE_DIRS
-		NAMES r_core.h r_bin.h r_util.h
-		HINTS
-			"$ENV{HOME}/bin/prefix/radare2/include/libr"
-			/usr/local/include/libr
-			/usr/include/libr)
-
-set(RADARE2_LIBRARY_NAMES
-		core
-		config
-		cons
-		io
-		util
-		flag
-		asm
-		debug
-		hash
-		bin
-		lang
-		io
-		anal
-		parse
-		bp
-		egg
-		reg
-		search
-		syscall
-		socket
-		fs
-		magic
-		crypto)
-
-set(RADARE2_LIBRARIES "")
-set(RADARE2_LIBRARIES_VARS "")
-foreach(libname ${RADARE2_LIBRARY_NAMES})
-	find_library(RADARE2_LIBRARY_${libname}
-			r_${libname}
+if(WIN32)
+	find_path(RADARE2_INCLUDE_DIRS
+			NAMES r_core.h r_bin.h r_util.h
 			HINTS
-				"$ENV{HOME}/bin/prefix/radare2/lib"
-				/usr/local/lib
-				/usr/lib)
+				"$ENV{HOME}/bin/prefix/radare2/include/libr"
+				/usr/local/include/libr
+				/usr/include/libr)
 
-	list(APPEND RADARE2_LIBRARIES ${RADARE2_LIBRARY_${libname}})
-	list(APPEND RADARE2_LIBRARIES_VARS "RADARE2_LIBRARY_${libname}")
-endforeach()
+	set(RADARE2_LIBRARY_NAMES
+			core
+			config
+			cons
+			io
+			util
+			flag
+			asm
+			debug
+			hash
+			bin
+			lang
+			io
+			anal
+			parse
+			bp
+			egg
+			reg
+			search
+			syscall
+			socket
+			fs
+			magic
+			crypto)
+
+	set(RADARE2_LIBRARIES "")
+	set(RADARE2_LIBRARIES_VARS "")
+	foreach(libname ${RADARE2_LIBRARY_NAMES})
+		find_library(RADARE2_LIBRARY_${libname}
+				r_${libname}
+				HINTS
+					"$ENV{HOME}/bin/prefix/radare2/lib"
+					/usr/local/lib
+					/usr/lib)
+
+		list(APPEND RADARE2_LIBRARIES ${RADARE2_LIBRARY_${libname}})
+		list(APPEND RADARE2_LIBRARIES_VARS "RADARE2_LIBRARY_${libname}")
+	endforeach()
+
+	set(RADARE2_LIBRARY_DIRS "")
+else()
+	# support sys/user.sh install
+	set(RADARE2_CMAKE_PREFIX_PATH_TEMP ${CMAKE_PREFIX_PATH})
+	list(APPEND CMAKE_PREFIX_PATH "$ENV{HOME}/bin/prefix/radare2")
+
+	find_package(PkgConfig REQUIRED)
+	pkg_search_module(RADARE2 REQUIRED r_core)
+
+	# reset CMAKE_PREFIX_PATH
+	set(CMAKE_PREFIX_PATH ${RADARE2_CMAKE_PREFIX_PATH_TEMP})
+	mark_as_advanced(RADARE2_CMAKE_PREFIX_PATH_TEMP)
+endif()
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(RADARE2 REQUIRED_VARS ${RADARE2_LIBRARIES_VARS} RADARE2_INCLUDE_DIRS)
+find_package_handle_standard_args(RADARE2 REQUIRED_VARS RADARE2_LIBRARIES RADARE2_INCLUDE_DIRS)
 
 mark_as_advanced(RADARE2_LIBRARIES_VARS)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,9 +30,8 @@ int main(int argc, char *argv[])
     cmdParser.addPositionalArgument("filename", QObject::tr("Filename to open."));
 
     QCommandLineOption analOption({"A", "anal"},
-                                  QObject::tr("Automatically start analysis. Needs filename to be specified. May be a value between 0 and 4. Default is 3."),
-                                  QObject::tr("level"),
-                                  "3");
+                                  QObject::tr("Automatically start analysis. Needs filename to be specified. May be a value between 0 and 4."),
+                                  QObject::tr("level"));
     cmdParser.addOption(analOption);
 
     cmdParser.process(a);

--- a/src/widgets/flagswidget.cpp
+++ b/src/widgets/flagswidget.cpp
@@ -10,19 +10,18 @@
 
 
 
-FlagsModel::FlagsModel(QList<FlagDescription> *flags, MainWindow *main, QObject *parent)
+FlagsModel::FlagsModel(QList<FlagDescription> *flags, QObject *parent)
     : QAbstractListModel(parent),
-      main(main),
       flags(flags)
 {
 }
 
-int FlagsModel::rowCount(const QModelIndex &parent) const
+int FlagsModel::rowCount(const QModelIndex &) const
 {
     return flags->count();
 }
 
-int FlagsModel::columnCount(const QModelIndex &parent) const
+int FlagsModel::columnCount(const QModelIndex &) const
 {
     return Columns::COUNT;
 }
@@ -136,7 +135,7 @@ FlagsWidget::FlagsWidget(MainWindow *main, QWidget *parent) :
 {
     ui->setupUi(this);
 
-    flags_model = new FlagsModel(&flags, main, this);
+    flags_model = new FlagsModel(&flags, this);
     flags_proxy_model = new FlagsSortFilterProxyModel(flags_model, this);
     connect(ui->filterLineEdit, SIGNAL(textChanged(const QString &)), flags_proxy_model, SLOT(setFilterWildcard(const QString &)));
     ui->flagsTreeView->setModel(flags_proxy_model);

--- a/src/widgets/flagswidget.h
+++ b/src/widgets/flagswidget.h
@@ -18,14 +18,13 @@ class FlagsModel: public QAbstractListModel
     Q_OBJECT
 
 private:
-    MainWindow *main;
     QList<FlagDescription> *flags;
 
 public:
     enum Columns { OFFSET = 0, SIZE, NAME, COUNT };
     static const int FlagDescriptionRole = Qt::UserRole;
 
-    FlagsModel(QList<FlagDescription> *flags, MainWindow *main, QObject *parent = 0);
+    FlagsModel(QList<FlagDescription> *flags, QObject *parent = 0);
 
     int rowCount(const QModelIndex &parent = QModelIndex()) const;
     int columnCount(const QModelIndex &parent = QModelIndex()) const;

--- a/src/widgets/flagswidget.h
+++ b/src/widgets/flagswidget.h
@@ -1,10 +1,57 @@
 #ifndef FLAGSWIDGET_H
 #define FLAGSWIDGET_H
 
+#include <QtCore/QAbstractItemModel>
+#include <qrcore.h>
+#include <QtCore/QSortFilterProxyModel>
 #include "dockwidget.h"
 
 class MainWindow;
 class QTreeWidgetItem;
+
+
+
+
+
+class FlagsModel: public QAbstractListModel
+{
+    Q_OBJECT
+
+private:
+    MainWindow *main;
+    QList<FlagDescription> *flags;
+
+public:
+    enum Columns { OFFSET = 0, SIZE, NAME, COUNT };
+    static const int FlagDescriptionRole = Qt::UserRole;
+
+    FlagsModel(QList<FlagDescription> *flags, MainWindow *main, QObject *parent = 0);
+
+    int rowCount(const QModelIndex &parent = QModelIndex()) const;
+    int columnCount(const QModelIndex &parent = QModelIndex()) const;
+
+    QVariant data(const QModelIndex &index, int role) const;
+    QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const;
+
+    void beginReloadFlags();
+    void endReloadFlags();
+};
+
+
+
+class FlagsSortFilterProxyModel : public QSortFilterProxyModel
+{
+    Q_OBJECT
+
+public:
+    FlagsSortFilterProxyModel(FlagsModel *source_model, QObject *parent = 0);
+
+protected:
+    bool filterAcceptsRow(int row, const QModelIndex &parent) const override;
+    bool lessThan(const QModelIndex &left, const QModelIndex &right) const override;
+};
+
+
 
 namespace Ui
 {
@@ -20,20 +67,19 @@ public:
     ~FlagsWidget();
 
     void setup() override;
-
     void refresh() override;
 
-    void clear();
-
-
 private slots:
-    void on_flagsTreeWidget_itemDoubleClicked(QTreeWidgetItem *item, int column);
-
+    void on_flagsTreeView_doubleClicked(const QModelIndex &index);
     void on_flagspaceCombo_currentTextChanged(const QString &arg1);
 
 private:
     Ui::FlagsWidget *ui;
     MainWindow      *main;
+
+    FlagsModel *flags_model;
+    FlagsSortFilterProxyModel *flags_proxy_model;
+    QList<FlagDescription> flags;
 
     void refreshFlags();
     void refreshFlagspaces();

--- a/src/widgets/flagswidget.ui
+++ b/src/widgets/flagswidget.ui
@@ -31,48 +31,9 @@
      <number>0</number>
     </property>
     <item>
-     <layout class="QHBoxLayout" name="horizontalLayout_17">
-      <property name="spacing">
-       <number>10</number>
-      </property>
-      <property name="leftMargin">
-       <number>10</number>
-      </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>5</number>
-      </property>
-      <item>
-       <widget class="QLabel" name="flagspaceLabel">
-        <property name="text">
-         <string>Flagspace:</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QComboBox" name="flagspaceCombo"/>
-      </item>
-      <item>
-       <spacer name="horizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-     </layout>
-    </item>
-    <item>
-     <widget class="QTreeWidget" name="flagsTreeWidget">
+     <widget class="QTreeView" name="flagsTreeView">
       <property name="styleSheet">
-       <string notr="true">QTreeWidget::item
+       <string notr="true">QTreeView::item
 {
     padding-left:10px;
     padding-top: 1px;
@@ -80,13 +41,13 @@
     border-left: 10px;
 }
 
-QTreeWidget::item:hover
+QTreeView::item:hover
 {
     background: rgb(242, 246, 248);
     color: black;
 }
 
-QTreeWidget::item:selected
+QTreeView::item:selected
 {
     background: gray;
     color: white;
@@ -98,39 +59,52 @@ QTreeWidget::item:selected
       <property name="dragEnabled">
        <bool>true</bool>
       </property>
+      <property name="indentation">
+       <number>0</number>
+      </property>
       <property name="sortingEnabled">
        <bool>true</bool>
       </property>
       <property name="animated">
        <bool>true</bool>
       </property>
-      <property name="allColumnsShowFocus">
-       <bool>false</bool>
-      </property>
-      <property name="columnCount">
-       <number>4</number>
-      </property>
-      <column>
-       <property name="text">
-        <string>Dummy</string>
-       </property>
-      </column>
-      <column>
-       <property name="text">
-        <string>Size</string>
-       </property>
-      </column>
-      <column>
-       <property name="text">
-        <string>Offset</string>
-       </property>
-      </column>
-      <column>
-       <property name="text">
-        <string notr="true">Name</string>
-       </property>
-      </column>
      </widget>
+    </item>
+    <item>
+     <layout class="QHBoxLayout" name="horizontalLayout_17">
+      <property name="spacing">
+       <number>10</number>
+      </property>
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QLineEdit" name="filterLineEdit">
+        <property name="text">
+         <string/>
+        </property>
+        <property name="placeholderText">
+         <string>Quick Filter</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="flagspaceLabel">
+        <property name="text">
+         <string>Flagspace:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QComboBox" name="flagspaceCombo"/>
+      </item>
+     </layout>
     </item>
    </layout>
   </widget>

--- a/src/widgets/functionswidget.cpp
+++ b/src/widgets/functionswidget.cpp
@@ -351,8 +351,8 @@ FunctionsWidget::FunctionsWidget(MainWindow *main, QWidget *parent) :
             this, SLOT(showFunctionsContextMenu(const QPoint &)));
 
 
-    connect(ui->functionsTreeView, SIGNAL(doubleClicked(const QModelIndex &)), this, SLOT(on_functionsTreeView_itemDoubleClicked(const QModelIndex &)));
-    connect(ui->nestedFunctionsTreeView, SIGNAL(doubleClicked(const QModelIndex &)), this, SLOT(on_functionsTreeView_itemDoubleClicked(const QModelIndex &)));
+    connect(ui->functionsTreeView, SIGNAL(doubleClicked(const QModelIndex &)), this, SLOT(functionsTreeView_doubleClicked(const QModelIndex &)));
+    connect(ui->nestedFunctionsTreeView, SIGNAL(doubleClicked(const QModelIndex &)), this, SLOT(functionsTreeView_doubleClicked(const QModelIndex &)));
 
     // Hide the tabs
     QTabBar *tabs = ui->tabWidget->tabBar();
@@ -410,7 +410,7 @@ QTreeView *FunctionsWidget::getCurrentTreeView()
         return ui->nestedFunctionsTreeView;
 }
 
-void FunctionsWidget::on_functionsTreeView_itemDoubleClicked(const QModelIndex &index)
+void FunctionsWidget::functionsTreeView_doubleClicked(const QModelIndex &index)
 {
     FunctionDescription function = index.data(FunctionModel::FunctionDescriptionRole).value<FunctionDescription>();
     this->main->seek(function.offset, function.name, true);

--- a/src/widgets/functionswidget.h
+++ b/src/widgets/functionswidget.h
@@ -89,7 +89,7 @@ public:
     void refresh() override;
 
 private slots:
-    void on_functionsTreeView_itemDoubleClicked(const QModelIndex &index);
+    void functionsTreeView_doubleClicked(const QModelIndex &index);
     void showFunctionsContextMenu(const QPoint &pt);
 
     void on_actionDisasAdd_comment_triggered();


### PR DESCRIPTION
Basically the same what I did with the FunctionsWidget, but much simpler since the FlagsWidget does not have the nested view. I also added the Quick Filter field.

Additionally, I removed the default value for the -A option, because this didn't work the way I thought. Unfortunately, QCommandLineParser does not support omitting the value for an option like this.

I have also moved the pkg-config stuff in CMake to FindRadare2.cmake to keep the actual CMakeLists.txt clean.