### PR TITLE
Fix webserver failure in appimage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,8 @@ script:
   - mkdir build ; cd build
   - qmake PREFIX=/usr ../src
   - make -j4
-  - sudo make INSTALL_ROOT=appdir install ; sudo chown -R $USER appdir ; find appdir/
+  - sudo make INSTALL_ROOT=appdir install ; sudo chown -R $USER appdir
+  - mkdir -p appdir/usr/share/radare2 ; cp -Lr /usr/share/radare2/*-git/ appdir/usr/share/radare2/ ; find appdir/
 
 after_success:
   - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: cpp
 compiler: gcc
+cache: ccache
 sudo: require
 dist: trusty
 

--- a/src/radarewebserver.cpp
+++ b/src/radarewebserver.cpp
@@ -1,5 +1,7 @@
 #include "radarewebserver.h"
 #include "qrcore.h"
+#include <QCoreApplication>
+#include <QProcessEnvironment>
 #include <cassert>
 
 
@@ -17,6 +19,23 @@ RadareWebServer::~RadareWebServer()
 void RadareWebServer::start()
 {
     assert(core != nullptr);
+
+    // FIXME: quick & dirty work around to get this in AppImage working
+    QProcessEnvironment env(QProcessEnvironment::systemEnvironment());
+    if (env.contains("APPIMAGE") && env.contains("APPDIR") && env.contains("OWD"))
+    {
+        // pretty sure now iaito runs as AppImage
+
+        //QString defaultPath("/usr/share/radare2/1.5.0-git/www");
+        QString defaultHttpRoot(core->config("http.root"));
+        if (defaultHttpRoot.startsWith("/usr"))
+        {
+            QString path(QCoreApplication::applicationDirPath());
+            path.replace("bin/", defaultHttpRoot.remove("/usr"));
+
+            core->config("http.root", path);
+        }
+    }
 
     if (!started && core != nullptr)
     {


### PR DESCRIPTION
The radare webserver is looking for http.root or http.homeroot which
wasn't included in the appimage, so the webserver failed to start.

Since sys/install.sh seems to just symlinks a lot of files in
/usr/share/radare2 cp -Lr the folder.
