### PR TITLE
Use custom qmake parameter for AppImage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ script:
   - sys/install.sh
   - cd ..
   - mkdir build ; cd build
-  - qmake PREFIX=/usr ../src
+  - qmake PREFIX=/usr APPIMAGE=1 ../src
   - make -j4
   - sudo make INSTALL_ROOT=appdir install ; sudo chown -R $USER appdir
   - mkdir -p appdir/usr/share/radare2 ; cp -Lr /usr/share/radare2/*-git/ appdir/usr/share/radare2/ ; find appdir/

--- a/src/iaito.pro
+++ b/src/iaito.pro
@@ -143,7 +143,6 @@ include(lib_radare2.pri)
 unix {
     isEmpty(PREFIX) {
         PREFIX = /usr/local
-        DEFAULT_PREFIX = true
     }
 
     desktop_file = iaito.desktop
@@ -159,8 +158,8 @@ unix {
 
     INSTALLS += target share_applications
 
-    # if a custom PREFIX is supplied, we asume it's an AppImage install
-    !defined(DEFAULT_PREFIX, var) {
+    # Triggered for example by 'qmake APPIMAGE=1'
+    !isEmpty(APPIMAGE){
         # UGLY work around for the logo name in iaito.desktop
         # Would be better to have a file called iaito.png in the first place
         system(cp img/logo-small.png $$OUT_PWD/iaito.png)


### PR DESCRIPTION
Install files for AppImage if a custom qmake parameter is supplied, not
by abusing PREFIX.

Add new paramter to .travis.yml