### PR TITLE
Fix X-Refs

### DIFF
--- a/src/dialogs/xrefsdialog.cpp
+++ b/src/dialogs/xrefsdialog.cpp
@@ -27,15 +27,15 @@ XrefsDialog::~XrefsDialog()
     delete ui;
 }
 
-void XrefsDialog::fillRefs(QList<QStringList> refs, QList<QStringList> xrefs)
+void XrefsDialog::fillRefs(QList<XRefDescription> refs, QList<XRefDescription> xrefs)
 {
     ui->fromTreeWidget->clear();
     for (int i = 0; i < refs.size(); ++i)
     {
         //this->add_debug_output(refs.at(i).at(0) + " " + refs.at(i).at(1));
         QTreeWidgetItem *tempItem = new QTreeWidgetItem();
-        tempItem->setText(0, refs.at(i).at(0));
-        tempItem->setText(1, refs.at(i).at(1));
+        tempItem->setText(0, RAddressString(refs.at(i).to));
+        tempItem->setText(1, refs.at(i).opcode);
         //tempItem->setToolTip( 0, this->main->core->cmd("pdi 10 @ " + refs.at(i).at(0)) );
         //tempItem->setToolTip( 1, this->main->core->cmd("pdi 10 @ " + refs.at(i).at(0)) );
         ui->fromTreeWidget->insertTopLevelItem(0, tempItem);
@@ -52,8 +52,8 @@ void XrefsDialog::fillRefs(QList<QStringList> refs, QList<QStringList> xrefs)
     {
         //this->add_debug_output(xrefs.at(i).at(0) + " " + xrefs.at(i).at(1));
         QTreeWidgetItem *tempItem = new QTreeWidgetItem();
-        tempItem->setText(0, xrefs.at(i).at(0));
-        tempItem->setText(1, xrefs.at(i).at(1));
+        tempItem->setText(0, RAddressString(xrefs.at(i).from));
+        tempItem->setText(1, xrefs.at(i).opcode);
         //tempItem->setToolTip( 0, this->main->core->cmd("pdi 10 @ " + xrefs.at(i).at(0)) );
         //tempItem->setToolTip( 1, this->main->core->cmd("pdi 10 @ " + xrefs.at(i).at(0)) );
         ui->toTreeWidget->insertTopLevelItem(0, tempItem);

--- a/src/dialogs/xrefsdialog.cpp
+++ b/src/dialogs/xrefsdialog.cpp
@@ -32,12 +32,15 @@ void XrefsDialog::fillRefs(QList<XRefDescription> refs, QList<XRefDescription> x
     ui->fromTreeWidget->clear();
     for (int i = 0; i < refs.size(); ++i)
     {
-        //this->add_debug_output(refs.at(i).at(0) + " " + refs.at(i).at(1));
+        XRefDescription xref = refs[i];
+
         QTreeWidgetItem *tempItem = new QTreeWidgetItem();
-        tempItem->setText(0, RAddressString(refs.at(i).to));
-        tempItem->setText(1, refs.at(i).opcode);
+        tempItem->setText(0, RAddressString(xref.to));
+        tempItem->setText(1, main->core->disassembleSingleInstruction(xref.from));
+        tempItem->setData(0, Qt::UserRole, QVariant::fromValue(xref));
         //tempItem->setToolTip( 0, this->main->core->cmd("pdi 10 @ " + refs.at(i).at(0)) );
         //tempItem->setToolTip( 1, this->main->core->cmd("pdi 10 @ " + refs.at(i).at(0)) );
+
         ui->fromTreeWidget->insertTopLevelItem(0, tempItem);
     }
     // Adjust columns to content
@@ -50,12 +53,15 @@ void XrefsDialog::fillRefs(QList<XRefDescription> refs, QList<XRefDescription> x
     ui->toTreeWidget->clear();
     for (int i = 0; i < xrefs.size(); ++i)
     {
-        //this->add_debug_output(xrefs.at(i).at(0) + " " + xrefs.at(i).at(1));
+        XRefDescription xref = xrefs[i];
+
         QTreeWidgetItem *tempItem = new QTreeWidgetItem();
-        tempItem->setText(0, RAddressString(xrefs.at(i).from));
-        tempItem->setText(1, xrefs.at(i).opcode);
+        tempItem->setText(0, RAddressString(xref.from));
+        tempItem->setText(1, main->core->disassembleSingleInstruction(xref.from));
+        tempItem->setData(0, Qt::UserRole, QVariant::fromValue(xref));
         //tempItem->setToolTip( 0, this->main->core->cmd("pdi 10 @ " + xrefs.at(i).at(0)) );
         //tempItem->setToolTip( 1, this->main->core->cmd("pdi 10 @ " + xrefs.at(i).at(0)) );
+
         ui->toTreeWidget->insertTopLevelItem(0, tempItem);
     }
     // Adjust columns to content
@@ -152,6 +158,21 @@ void XrefsDialog::on_toTreeWidget_itemSelectionChanged()
 
 void XrefsDialog::updateLabels(QString name)
 {
-    ui->label_2->setText(ui->label_2->text() + name);
-    ui->label_3->setText(ui->label_3->text() + name);
+    ui->label_2->setText(tr("X-Refs to %1:").arg(name));
+    ui->label_3->setText(tr("X-Refs from %1:").arg(name));
+}
+
+void XrefsDialog::fillRefsForFunction(RVA addr, QString name)
+{
+    setWindowTitle(tr("X-Refs for function %1").arg(name));
+    updateLabels(name);
+    // Get Refs and Xrefs
+
+    // refs = calls q hace esa funcion
+    QList<XRefDescription> refs = main->core->getXRefs(addr, false, "C");
+
+    // xrefs = calls a esa funcion
+    QList<XRefDescription> xrefs = main->core->getXRefs(addr, true);
+
+    fillRefs(refs, xrefs);
 }

--- a/src/dialogs/xrefsdialog.h
+++ b/src/dialogs/xrefsdialog.h
@@ -38,13 +38,17 @@ private slots:
     void on_toTreeWidget_itemSelectionChanged();
 
 private:
+    RVA addr;
+    QString func_name;
+
     Ui::XrefsDialog *ui;
     MainWindow *main;
 
     Highlighter      *highlighter;
 
-    void fillRefs(QList<XRefDescription> refs, QList<XRefDescription> xrefs);
+    void fillRefs(QList<XrefDescription> refs, QList<XrefDescription> xrefs);
     void updateLabels(QString name);
+    void updatePreview(RVA addr);
 
 };
 

--- a/src/dialogs/xrefsdialog.h
+++ b/src/dialogs/xrefsdialog.h
@@ -22,8 +22,7 @@ public:
     explicit XrefsDialog(MainWindow *main, QWidget *parent = 0);
     ~XrefsDialog();
 
-    void fillRefs(QList<XRefDescription> refs, QList<XRefDescription> xrefs);
-    void updateLabels(QString name);
+    void fillRefsForFunction(RVA addr, QString name);
 
 private slots:
 
@@ -43,6 +42,9 @@ private:
     MainWindow *main;
 
     Highlighter      *highlighter;
+
+    void fillRefs(QList<XRefDescription> refs, QList<XRefDescription> xrefs);
+    void updateLabels(QString name);
 
 };
 

--- a/src/dialogs/xrefsdialog.h
+++ b/src/dialogs/xrefsdialog.h
@@ -2,6 +2,7 @@
 #define XREFSDIALOG_H
 
 #include "highlighter.h"
+#include "qrcore.h"
 
 #include <QDialog>
 #include <QTreeWidgetItem>
@@ -21,7 +22,7 @@ public:
     explicit XrefsDialog(MainWindow *main, QWidget *parent = 0);
     ~XrefsDialog();
 
-    void fillRefs(QList<QStringList> refs, QList<QStringList> xrefs);
+    void fillRefs(QList<XRefDescription> refs, QList<XRefDescription> xrefs);
     void updateLabels(QString name);
 
 private slots:

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -327,7 +327,6 @@ void MainWindow::finalizeOpen()
     core->cmd("fs sections");
     updateFrames();
 
-    get_refs(core->cmd("?v entry0"));
     memoryDock->selectHexPreview();
 
     // Restore project notes
@@ -770,7 +769,7 @@ void MainWindow::seek(const RVA offset, const QString &name, bool raise_memory_d
     core->seek(offset);
     setCursorAddress(offset);
 
-    refreshMem(offset);
+    refreshMem();
     this->memoryDock->disasTextEdit->setFocus();
 
     // Rise and shine baby!
@@ -781,22 +780,8 @@ void MainWindow::seek(const RVA offset, const QString &name, bool raise_memory_d
 void MainWindow::refreshMem()
 {
     this->memoryDock->updateViews();
-
 }
 
-void MainWindow::refreshMem(RVA offset)
-{
-    //add_debug_output("Refreshing to: " + off);
-    //graphicsBar->refreshColorBar();
-    /*
-    this->memoryDock->refreshDisasm(off);
-    this->memoryDock->refreshHexdump(off);
-    this->memoryDock->create_graph(off);
-    */
-    refreshMem();
-    this->memoryDock->get_refs_data(RAddressString(offset));
-    //this->memoryDock->setFcnName(offset);
-}
 
 void MainWindow::on_backButton_clicked()
 {
@@ -920,11 +905,6 @@ void MainWindow::on_actionFunctionsRename_triggered()
     // Get function based on click position
     //r->setFunctionName(fcn_name);
     r->open();
-}
-
-void MainWindow::get_refs(const QString &offset)
-{
-    this->memoryDock->get_refs_data(offset);
 }
 
 void MainWindow::addOutput(const QString &msg)

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -71,7 +71,6 @@ public:
     void updateFrames();
     void refreshFunctions();
     void refreshComments();
-    void get_refs(const QString &offset);
     void addOutput(const QString &msg);
     void addDebugOutput(const QString &msg);
     void sendToNotepad(const QString &txt);
@@ -180,7 +179,6 @@ private:
 
     bool doLock;
     void refreshMem();
-    void refreshMem(RVA offset);
     ut64 hexdumpTopOffset;
     ut64 hexdumpBottomOffset;
     QString filename;

--- a/src/qrcore.cpp
+++ b/src/qrcore.cpp
@@ -398,6 +398,8 @@ bool QRCore::tryFile(QString path, bool rw)
     return true;
 }
 
+
+
 QList<QString> QRCore::getList(const QString &type, const QString &subtype)
 {
     CORE_LOCK();
@@ -561,6 +563,11 @@ QString QRCore::disassemble(const QString &hex)
     QString code = QString(ac != nullptr ? ac->buf_asm : "");
     r_asm_code_free(ac);
     return code;
+}
+
+QString QRCore::disassembleSingleInstruction(RVA addr)
+{
+    return cmd("pi 1@" + QString::number(addr)).simplified();
 }
 
 RAnalFunction *QRCore::functionAt(ut64 addr)
@@ -1155,10 +1162,6 @@ QList<XRefDescription> QRCore::getXRefs(RVA addr, bool to, const QString &filter
             xref.to = addr;
         else
             xref.to = xrefObject["to"].toVariant().toULongLong();
-
-        xref.opcode = xrefObject["opcode"].toString();
-
-        printf("xref %s %s\n", to ? "to" : "from", xref.opcode.toLocal8Bit().constData());
 
         ret << xref;
     }

--- a/src/qrcore.h
+++ b/src/qrcore.h
@@ -139,7 +139,6 @@ struct XRefDescription
     RVA from;
     RVA to;
     QString type;
-    QString opcode;
 };
 
 Q_DECLARE_METATYPE(FunctionDescription)
@@ -151,6 +150,7 @@ Q_DECLARE_METATYPE(RelocDescription)
 Q_DECLARE_METATYPE(StringDescription)
 Q_DECLARE_METATYPE(FlagspaceDescription)
 Q_DECLARE_METATYPE(FlagDescription)
+Q_DECLARE_METATYPE(XRefDescription)
 
 class QRCore : public QObject
 {
@@ -187,6 +187,7 @@ public:
     int config(const QString &k, int v);
     QString assemble(const QString &code);
     QString disassemble(const QString &hex);
+    QString disassembleSingleInstruction(RVA addr);
     void setDefaultCPU();
     void setCPU(QString arch, QString cpu, int bits, bool temporary = false);
     RAnalFunction *functionAt(ut64 addr);

--- a/src/qrcore.h
+++ b/src/qrcore.h
@@ -134,6 +134,14 @@ struct SectionDescription
     QString flags;
 };
 
+struct XRefDescription
+{
+    RVA from;
+    RVA to;
+    QString type;
+    QString opcode;
+};
+
 Q_DECLARE_METATYPE(FunctionDescription)
 Q_DECLARE_METATYPE(ImportDescription)
 Q_DECLARE_METATYPE(ExportDescription)
@@ -155,8 +163,6 @@ public:
     ~QRCore();
 
     RVA getOffset() const                           { return core_->offset; }
-    QList<QString> getFunctionXrefs(ut64 addr);
-    QList<QString> getFunctionRefs(ut64 addr, char type);
     int getCycloComplex(ut64 addr);
     int getFcnSize(ut64 addr);
     int fcnCyclomaticComplexity(ut64 addr);
@@ -226,6 +232,11 @@ public:
     QList<FlagspaceDescription> getAllFlagspaces();
     QList<FlagDescription> getAllFlags(QString flagspace = NULL);
     QList<SectionDescription> getAllSections();
+
+
+    QList<QString> getFunctionXrefs(ut64 addr);
+    QList<QString> getFunctionRefs(ut64 addr, char type);
+    QList<XRefDescription> getXRefs(RVA addr, bool to, const QString &filterType = QString::null);
 
     RCoreLocked core() const;
 

--- a/src/qrcore.h
+++ b/src/qrcore.h
@@ -134,7 +134,7 @@ struct SectionDescription
     QString flags;
 };
 
-struct XRefDescription
+struct XrefDescription
 {
     RVA from;
     RVA to;
@@ -150,7 +150,7 @@ Q_DECLARE_METATYPE(RelocDescription)
 Q_DECLARE_METATYPE(StringDescription)
 Q_DECLARE_METATYPE(FlagspaceDescription)
 Q_DECLARE_METATYPE(FlagDescription)
-Q_DECLARE_METATYPE(XRefDescription)
+Q_DECLARE_METATYPE(XrefDescription)
 
 class QRCore : public QObject
 {
@@ -167,7 +167,7 @@ public:
     int getFcnSize(ut64 addr);
     int fcnCyclomaticComplexity(ut64 addr);
     int fcnBasicBlockCount(ut64 addr);
-    int fcnEndBbs(QString addr);
+    int fcnEndBbs(RVA addr);
     QString cmd(const QString &str);
     QJsonDocument cmdj(const QString &str);
     void renameFunction(QString prev_name, QString new_name);
@@ -234,10 +234,7 @@ public:
     QList<FlagDescription> getAllFlags(QString flagspace = NULL);
     QList<SectionDescription> getAllSections();
 
-
-    QList<QString> getFunctionXrefs(ut64 addr);
-    QList<QString> getFunctionRefs(ut64 addr, char type);
-    QList<XRefDescription> getXRefs(RVA addr, bool to, const QString &filterType = QString::null);
+    QList<XrefDescription> getXRefs(RVA addr, bool to, const QString &filterType = QString::null);
 
     RCoreLocked core() const;
 

--- a/src/widgets/functionswidget.cpp
+++ b/src/widgets/functionswidget.cpp
@@ -518,44 +518,14 @@ void FunctionsWidget::on_action_References_triggered()
     x->setWindowTitle("X-Refs for function " + QString::fromUtf8(fcn->name));
 
     // Get Refs and Xrefs
-    QList<QStringList> ret_refs;
-    QList<QStringList> ret_xrefs;
 
     // refs = calls q hace esa funcion
-    QList<QString> refs = this->main->core->getFunctionRefs(fcn->addr, 'C');
-    if (refs.size() > 0)
-    {
-        for (int i = 0; i < refs.size(); ++i)
-        {
-            //this->main->add_debug_output(refs.at(i));
-            QStringList retlist = refs.at(i).split(",");
-            QStringList temp;
-            QString addr = retlist.at(2);
-            temp << addr;
-            QString op = this->main->core->cmd("pi 1 @ " + addr);
-            temp << op.simplified();
-            ret_refs << temp;
-        }
-    }
+    QList<XRefDescription> refs = main->core->getXRefs(fcn->addr, false, "C");
 
     // xrefs = calls a esa funcion
-    //qDebug() << this->main->core->getFunctionXrefs(offset.toLong(&ok, 16));
-    QList<QString> xrefs = this->main->core->getFunctionXrefs(fcn->addr);
-    if (xrefs.size() > 0)
-    {
-        for (int i = 0; i < xrefs.size(); ++i)
-        {
-            //this->main->add_debug_output(xrefs.at(i));
-            QStringList retlist = xrefs.at(i).split(",");
-            QStringList temp;
-            QString addr = retlist.at(1);
-            temp << addr;
-            QString op = this->main->core->cmd("pi 1 @ " + addr);
-            temp << op.simplified();
-            ret_xrefs << temp;
-        }
-    }
-    x->fillRefs(ret_refs, ret_xrefs);
+    QList<XRefDescription> xrefs = main->core->getXRefs(fcn->addr, true);
+
+    x->fillRefs(refs, xrefs);
     x->exec();
 }
 

--- a/src/widgets/functionswidget.cpp
+++ b/src/widgets/functionswidget.cpp
@@ -508,24 +508,8 @@ void FunctionsWidget::on_action_References_triggered()
     // Get selected item in functions tree view
     QTreeView *treeView = getCurrentTreeView();
     FunctionDescription function = treeView->selectionModel()->currentIndex().data(FunctionModel::FunctionDescriptionRole).value<FunctionDescription>();
-
-    //this->main->add_debug_output("Addr: " + address);
-
-    // Get function for clicked offset
-    RAnalFunction *fcn = this->main->core->functionAt(function.offset);
-
     XrefsDialog *x = new XrefsDialog(this->main, this);
-    x->setWindowTitle("X-Refs for function " + QString::fromUtf8(fcn->name));
-
-    // Get Refs and Xrefs
-
-    // refs = calls q hace esa funcion
-    QList<XRefDescription> refs = main->core->getXRefs(fcn->addr, false, "C");
-
-    // xrefs = calls a esa funcion
-    QList<XRefDescription> xrefs = main->core->getXRefs(fcn->addr, true);
-
-    x->fillRefs(refs, xrefs);
+    x->fillRefsForFunction(function.offset, function.name);
     x->exec();
 }
 

--- a/src/widgets/memorywidget.cpp
+++ b/src/widgets/memorywidget.cpp
@@ -1880,44 +1880,14 @@ void MemoryWidget::on_actionXRefs_triggered()
         x->updateLabels(QString(fcn->name));
 
         // Get Refs and Xrefs
-        QList<QStringList> ret_refs;
-        QList<QStringList> ret_xrefs;
 
         // refs = calls q hace esa funcion
-        QList<QString> refs = this->main->core->getFunctionRefs(fcn->addr, 'C');
-        if (refs.size() > 0)
-        {
-            for (int i = 0; i < refs.size(); ++i)
-            {
-                //this->main->add_debug_output(refs.at(i));
-                QStringList retlist = refs.at(i).split(",");
-                QStringList temp;
-                QString addr = retlist.at(2);
-                temp << addr;
-                QString op = this->main->core->cmd("pi 1 @ " + addr);
-                temp << op.simplified();
-                ret_refs << temp;
-            }
-        }
+        QList<XRefDescription> refs = main->core->getXRefs(fcn->addr, false, "C");
 
         // xrefs = calls a esa funcion
-        //qDebug() << this->main->core->getFunctionXrefs(offset.toLong(&ok, 16));
-        QList<QString> xrefs = this->main->core->getFunctionXrefs(fcn->addr);
-        if (xrefs.size() > 0)
-        {
-            for (int i = 0; i < xrefs.size(); ++i)
-            {
-                //this->main->add_debug_output(xrefs.at(i));
-                QStringList retlist = xrefs.at(i).split(",");
-                QStringList temp;
-                QString addr = retlist.at(1);
-                temp << addr;
-                QString op = this->main->core->cmd("pi 1 @ " + addr);
-                temp << op.simplified();
-                ret_xrefs << temp;
-            }
-        }
-        x->fillRefs(ret_refs, ret_xrefs);
+        QList<XRefDescription> xrefs = main->core->getXRefs(fcn->addr, true);
+
+        x->fillRefs(refs, xrefs);
         x->exec();
     }
 }

--- a/src/widgets/memorywidget.cpp
+++ b/src/widgets/memorywidget.cpp
@@ -1876,18 +1876,7 @@ void MemoryWidget::on_actionXRefs_triggered()
             return;
         }
         XrefsDialog *x = new XrefsDialog(this->main, this);
-        x->setWindowTitle("X-Refs for function " + QString(fcn->name));
-        x->updateLabels(QString(fcn->name));
-
-        // Get Refs and Xrefs
-
-        // refs = calls q hace esa funcion
-        QList<XRefDescription> refs = main->core->getXRefs(fcn->addr, false, "C");
-
-        // xrefs = calls a esa funcion
-        QList<XRefDescription> xrefs = main->core->getXRefs(fcn->addr, true);
-
-        x->fillRefs(refs, xrefs);
+        x->fillRefsForFunction(fcn->addr, QString::fromUtf8(fcn->name));
         x->exec();
     }
 }

--- a/src/widgets/memorywidget.h
+++ b/src/widgets/memorywidget.h
@@ -70,11 +70,9 @@ public slots:
 
     void refreshHexdump(const QString &where = QString());
 
-    void fill_refs(QList<QStringList> refs, QList<QStringList> xrefs, QList<int> graph_data);
+    void fill_refs(QList<XrefDescription> refs, QList<XrefDescription> xrefs, QList<int> graph_data);
 
     void fillOffsetInfo(QString off);
-
-    void get_refs_data(const QString &offset);
 
     void seek_to(const QString &offset);
 
@@ -112,6 +110,7 @@ private:
     RVA last_hexdump_fcn;
 
     void setFcnName(RVA addr);
+    void get_refs_data(RVA addr);
 
     void setScrollMode();
 

--- a/src/widgets/memorywidget.ui
+++ b/src/widgets/memorywidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>990</width>
-    <height>767</height>
+    <width>1078</width>
+    <height>815</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -1325,7 +1325,7 @@ border-top: 0px;
            <property name="geometry">
             <rect>
              <x>0</x>
-             <y>-175</y>
+             <y>-127</y>
              <width>256</width>
              <height>887</height>
             </rect>
@@ -1866,20 +1866,17 @@ color: rgb(0, 0, 0);</string>
                </widget>
               </item>
               <item>
-               <layout class="QHBoxLayout" name="horizontalLayout_15">
+               <layout class="QHBoxLayout" name="horizontalLayout_16">
                 <property name="spacing">
                  <number>5</number>
-                </property>
-                <property name="leftMargin">
-                 <number>0</number>
                 </property>
                 <property name="topMargin">
                  <number>0</number>
                 </property>
                 <item>
-                 <widget class="QToolButton" name="xrefFromToolButton_2">
+                 <widget class="QToolButton" name="xrefToToolButton_2">
                   <property name="text">
-                   <string/>
+                   <string>...</string>
                   </property>
                   <property name="iconSize">
                    <size>
@@ -1899,16 +1896,22 @@ color: rgb(0, 0, 0);</string>
                  </widget>
                 </item>
                 <item>
-                 <widget class="QLabel" name="xrefFromLabel_2">
+                 <widget class="QLabel" name="xrefToLabel_2">
+                  <property name="font">
+                   <font>
+                    <weight>75</weight>
+                    <bold>true</bold>
+                   </font>
+                  </property>
                   <property name="text">
-                   <string>&lt;b&gt;Xrefs from:&lt;/b&gt;</string>
+                   <string>X-Refs to current address:</string>
                   </property>
                  </widget>
                 </item>
                </layout>
               </item>
               <item>
-               <widget class="QTreeWidget" name="xreFromTreeWidget_2">
+               <widget class="QTreeWidget" name="xrefToTreeWidget_2">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
                   <horstretch>0</horstretch>
@@ -1974,17 +1977,20 @@ QToolTip {
                </widget>
               </item>
               <item>
-               <layout class="QHBoxLayout" name="horizontalLayout_16">
+               <layout class="QHBoxLayout" name="horizontalLayout_15">
                 <property name="spacing">
                  <number>5</number>
+                </property>
+                <property name="leftMargin">
+                 <number>0</number>
                 </property>
                 <property name="topMargin">
                  <number>0</number>
                 </property>
                 <item>
-                 <widget class="QToolButton" name="xrefToToolButton_2">
+                 <widget class="QToolButton" name="xrefFromToolButton_2">
                   <property name="text">
-                   <string>...</string>
+                   <string/>
                   </property>
                   <property name="iconSize">
                    <size>
@@ -2004,16 +2010,22 @@ QToolTip {
                  </widget>
                 </item>
                 <item>
-                 <widget class="QLabel" name="xrefToLabel_2">
+                 <widget class="QLabel" name="xrefFromLabel_2">
+                  <property name="font">
+                   <font>
+                    <weight>75</weight>
+                    <bold>true</bold>
+                   </font>
+                  </property>
                   <property name="text">
-                   <string>&lt;b&gt;Xrefs To:&lt;/b&gt;</string>
+                   <string>X-Refs from current address:</string>
                   </property>
                  </widget>
                 </item>
                </layout>
               </item>
               <item>
-               <widget class="QTreeWidget" name="xrefToTreeWidget_2">
+               <widget class="QTreeWidget" name="xreFromTreeWidget_2">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
                   <horstretch>0</horstretch>
@@ -3031,8 +3043,8 @@ QToolTip {
  </resources>
  <connections/>
  <buttongroups>
+  <buttongroup name="buttonGroup_2"/>
   <buttongroup name="buttonGroup"/>
   <buttongroup name="buttonGroup_3"/>
-  <buttongroup name="buttonGroup_2"/>
  </buttongroups>
 </ui>

--- a/src/widgets/memorywidget.ui
+++ b/src/widgets/memorywidget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>950</width>
+    <width>990</width>
     <height>767</height>
    </rect>
   </property>
@@ -933,7 +933,7 @@ QToolTip {
                  <number>0</number>
                 </property>
                 <item>
-                 <widget class="QWebEngineView" name="webSimpleGraph" native="true">
+                 <widget class="QWebEngineView" name="webSimpleGraph">
                   <property name="sizePolicy">
                    <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
                     <horstretch>0</horstretch>
@@ -954,7 +954,7 @@ QToolTip {
 	font: 11pt &quot;Monaco&quot;;
 }</string>
                   </property>
-                  <property name="url" stdset="0">
+                  <property name="url">
                    <url>
                     <string>about:blank</string>
                    </url>
@@ -1229,16 +1229,16 @@ p, li { white-space: pre-wrap; }
          <number>0</number>
         </property>
         <item>
-         <widget class="QWebEngineView" name="graphWebView" native="true">
+         <widget class="QWebEngineView" name="graphWebView">
           <property name="contextMenuPolicy">
            <enum>Qt::DefaultContextMenu</enum>
           </property>
-          <property name="url" stdset="0">
+          <property name="url">
            <url>
             <string>about:blank</string>
            </url>
           </property>
-          <property name="zoomFactor" stdset="0">
+          <property name="zoomFactor">
            <double>1.000000000000000</double>
           </property>
          </widget>
@@ -1325,9 +1325,9 @@ border-top: 0px;
            <property name="geometry">
             <rect>
              <x>0</x>
-             <y>0</y>
-             <width>257</width>
-             <height>885</height>
+             <y>-175</y>
+             <width>256</width>
+             <height>887</height>
             </rect>
            </property>
            <property name="sizePolicy">
@@ -1629,7 +1629,7 @@ QToolTip {
                    <number>0</number>
                   </property>
                   <item>
-                   <widget class="QWebEngineView" name="fcnWebView" native="true">
+                   <widget class="QWebEngineView" name="fcnWebView">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                       <horstretch>0</horstretch>
@@ -1648,7 +1648,7 @@ QToolTip {
                       <height>250</height>
                      </size>
                     </property>
-                    <property name="url" stdset="0">
+                    <property name="url">
                      <url>
                       <string>qrc:/html/fcn_graph.html</string>
                      </url>
@@ -1678,7 +1678,7 @@ QToolTip {
                    <number>0</number>
                   </property>
                   <item>
-                   <widget class="QWebEngineView" name="radarGraphWebView" native="true">
+                   <widget class="QWebEngineView" name="radarGraphWebView">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                       <horstretch>0</horstretch>
@@ -1697,7 +1697,7 @@ QToolTip {
                       <height>250</height>
                      </size>
                     </property>
-                    <property name="url" stdset="0">
+                    <property name="url">
                      <url>
                       <string>qrc:/html/fcn_radar.html</string>
                      </url>
@@ -1769,11 +1769,6 @@ QToolTip {
                   <width>0</width>
                   <height>175</height>
                  </size>
-                </property>
-                <property name="font">
-                 <font>
-                  <pointsize>11</pointsize>
-                 </font>
                 </property>
                 <property name="frameShape">
                  <enum>QFrame::NoFrame</enum>
@@ -1926,11 +1921,6 @@ color: rgb(0, 0, 0);</string>
                   <height>100</height>
                  </size>
                 </property>
-                <property name="font">
-                 <font>
-                  <pointsize>11</pointsize>
-                 </font>
-                </property>
                 <property name="styleSheet">
                  <string notr="true">QTreeWidget::item
 {
@@ -2035,11 +2025,6 @@ QToolTip {
                   <width>0</width>
                   <height>100</height>
                  </size>
-                </property>
-                <property name="font">
-                 <font>
-                  <pointsize>11</pointsize>
-                 </font>
                 </property>
                 <property name="styleSheet">
                  <string notr="true">QTreeWidget::item
@@ -3038,7 +3023,7 @@ QToolTip {
   <customwidget>
    <class>QWebEngineView</class>
    <extends>QWidget</extends>
-   <header>QtWebEngineWidgets/QWebEngineView</header>
+   <header location="global">QtWebEngineWidgets/QWebEngineView</header>
   </customwidget>
  </customwidgets>
  <resources>
@@ -3046,8 +3031,8 @@ QToolTip {
  </resources>
  <connections/>
  <buttongroups>
-  <buttongroup name="buttonGroup_2"/>
-  <buttongroup name="buttonGroup_3"/>
   <buttongroup name="buttonGroup"/>
+  <buttongroup name="buttonGroup_3"/>
+  <buttongroup name="buttonGroup_2"/>
  </buttongroups>
 </ui>


### PR DESCRIPTION
Fixes #175 (the crash described in the comments, maybe not the one by OP) and should fix #7

- X-Refs are fetched using `axtj` and `axfj` instead of radare api
- Disassembly preview in the XrefsDialog shows `pdf` if there is a function around the address or `pd 10` otherwise
- X-Refs in MemoryWidget sidebar are only updated on setup and always on_cursorAddressChanged, so it should be always up to date

I kept the filtering for code-only references, but I personally would rather remove it to also have data X-Refs. This is easy, just omit the filterType parameter in calls to `QRCore::getXRefs()`.

X-Refs from current address in the sidebar currently shows all X-Refs from the whole function, which is what `axf` returns.
This is different from what `VX` does, for example. I personally would filter for the actual address, which would be easy to do too.
X-Refs from the whole function would still be available from the XrefsDialog.

In the lists, "X-Refs to" displays the **to**-address and the instruction at the **to**-address, "X-Refs from" shows the **to**-address and the instruction at the **from**-address, like this:
![bildschirmfoto vom 2017-06-07 21-53-24](https://user-images.githubusercontent.com/1460997/26898343-ca7476fe-4bcb-11e7-9a59-953bf28ec4e8.png)
Is that what we want?

Please note that by "X-Refs to", I always mean "from somewhere else to the selected address" and by "X-Refs from" "from the selected address to somewhere else"