### PR TITLE
Trigger CMake reconfigure if iaito.pro changes and disallow in-source builds.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,13 @@ cmake_minimum_required(VERSION 3.1)
 
 project(Iaito VERSION 1.0.0)
 
+get_filename_component(SRC_DIR_REALPATH "${CMAKE_SOURCE_DIR}" REALPATH)
+get_filename_component(BINARY_DIR_REALPATH "${CMAKE_BINARY_DIR}" REALPATH)
+if(SRC_DIR_REALPATH STREQUAL BINARY_DIR_REALPATH)
+    message(FATAL_ERROR "In-source builds are not allowed.
+Please run CMake from a different build directory.")
+endif()
+
 set(CMAKE_CXX_STANDARD 11)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,18 +1,12 @@
 
 cmake_minimum_required(VERSION 3.1)
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+include(DisallowInSource)
+
 project(Iaito VERSION 1.0.0)
 
-get_filename_component(SRC_DIR_REALPATH "${CMAKE_SOURCE_DIR}" REALPATH)
-get_filename_component(BINARY_DIR_REALPATH "${CMAKE_BINARY_DIR}" REALPATH)
-if(SRC_DIR_REALPATH STREQUAL BINARY_DIR_REALPATH)
-    message(FATAL_ERROR "In-source builds are not allowed.
-Please run CMake from a different build directory.")
-endif()
-
 set(CMAKE_CXX_STANDARD 11)
-
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,7 +42,10 @@ endif()
 
 # Parse iaito.pro to get filenames
 include(QMakeProParse)
-parse_qmake_pro("${CMAKE_CURRENT_SOURCE_DIR}/iaito.pro" IAITO_PRO)
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/iaito.pro"
+        "${CMAKE_CURRENT_BINARY_DIR}/iaito.pro"
+        COPYONLY) # trigger reconfigure if iaito.pro changes
+parse_qmake_pro("${CMAKE_CURRENT_BINARY_DIR}/iaito.pro" IAITO_PRO)
 set(SOURCE_FILES ${IAITO_PRO_SOURCES})
 set(HEADER_FILES ${IAITO_PRO_HEADERS})
 set(UI_FILES ${IAITO_PRO_FORMS})

--- a/src/cmake/DisallowInSource.cmake
+++ b/src/cmake/DisallowInSource.cmake
@@ -1,0 +1,13 @@
+function(DisallowInSource)
+	get_filename_component(SRC_DIR_REALPATH "${CMAKE_SOURCE_DIR}" REALPATH)
+	get_filename_component(BINARY_DIR_REALPATH "${CMAKE_BINARY_DIR}" REALPATH)
+	if(SRC_DIR_REALPATH STREQUAL BINARY_DIR_REALPATH)
+		message(FATAL_ERROR " In-source builds are not allowed.
+ Please create a directory and run cmake from there:
+ mkdir build && cd build && cmake ..
+ This process created the file CMakeCache.txt and the directory CMakeFiles in ${CMAKE_SOURCE_DIR}.
+ Please delete them manually!")
+	endif()
+endfunction()
+
+DisallowInSource()


### PR DESCRIPTION
Just a small fix, so cmake does not have to be rerun if iaito.pro changes to update all the filenames.

In-source builds are also disallowed with this, because they can introduce problems.