### PR TITLE
Some more X-Ref changes

### DIFF
--- a/src/dialogs/xrefsdialog.cpp
+++ b/src/dialogs/xrefsdialog.cpp
@@ -192,7 +192,7 @@ void XrefsDialog::fillRefsForFunction(RVA addr, QString name)
     // Get Refs and Xrefs
 
     // refs = calls q hace esa funcion
-    QList<XrefDescription> refs = main->core->getXRefs(addr, false, "C");
+    QList<XrefDescription> refs = main->core->getXRefs(addr, false);
 
     // xrefs = calls a esa funcion
     QList<XrefDescription> xrefs = main->core->getXRefs(addr, true);

--- a/src/dialogs/xrefsdialog.cpp
+++ b/src/dialogs/xrefsdialog.cpp
@@ -182,20 +182,20 @@ void XrefsDialog::updateLabels(QString name)
     ui->label_3->setText(tr("X-Refs from %1:").arg(name));
 }
 
-void XrefsDialog::fillRefsForFunction(RVA addr, QString name)
+void XrefsDialog::fillRefsForAddress(RVA addr, QString name, bool whole_function)
 {
     this->addr = addr;
     this->func_name = func_name;
 
-    setWindowTitle(tr("X-Refs for function %1").arg(name));
+    setWindowTitle(tr("X-Refs for %1").arg(name));
     updateLabels(name);
     // Get Refs and Xrefs
 
     // refs = calls q hace esa funcion
-    QList<XrefDescription> refs = main->core->getXRefs(addr, false);
+    QList<XrefDescription> refs = main->core->getXRefs(addr, false, whole_function);
 
     // xrefs = calls a esa funcion
-    QList<XrefDescription> xrefs = main->core->getXRefs(addr, true);
+    QList<XrefDescription> xrefs = main->core->getXRefs(addr, true, whole_function);
 
     fillRefs(refs, xrefs);
 }

--- a/src/dialogs/xrefsdialog.h
+++ b/src/dialogs/xrefsdialog.h
@@ -22,7 +22,7 @@ public:
     explicit XrefsDialog(MainWindow *main, QWidget *parent = 0);
     ~XrefsDialog();
 
-    void fillRefsForFunction(RVA addr, QString name);
+    void fillRefsForAddress(RVA addr, QString name, bool whole_function);
 
 private slots:
 

--- a/src/qrcore.cpp
+++ b/src/qrcore.cpp
@@ -1090,7 +1090,7 @@ QList<SectionDescription> QRCore::getAllSections()
     return ret;
 }
 
-QList<XrefDescription> QRCore::getXRefs(RVA addr, bool to, const QString &filterType)
+QList<XrefDescription> QRCore::getXRefs(RVA addr, bool to, bool whole_function, const QString &filterType)
 {
     QList<XrefDescription> ret = QList<XrefDescription>();
 
@@ -1112,6 +1112,9 @@ QList<XrefDescription> QRCore::getXRefs(RVA addr, bool to, const QString &filter
             continue;
 
         xref.from = xrefObject["from"].toVariant().toULongLong();
+
+        if (!whole_function && !to && xref.from != addr)
+            continue;
 
         if (to && !xrefObject.contains("to"))
             xref.to = addr;

--- a/src/qrcore.h
+++ b/src/qrcore.h
@@ -234,7 +234,7 @@ public:
     QList<FlagDescription> getAllFlags(QString flagspace = NULL);
     QList<SectionDescription> getAllSections();
 
-    QList<XrefDescription> getXRefs(RVA addr, bool to, const QString &filterType = QString::null);
+    QList<XrefDescription> getXRefs(RVA addr, bool to, bool whole_function, const QString &filterType = QString::null);
 
     RCoreLocked core() const;
 

--- a/src/widgets/dashboard.cpp
+++ b/src/widgets/dashboard.cpp
@@ -72,8 +72,8 @@ void Dashboard::updateContents()
     this->ui->compiledEdit->setText(item2["compiled"].toString());
     this->ui->bitsEdit->setText(QString::number(item2["bits"].toDouble()));
 
-    QString relro=item2["relro"].toString().split(" ").at(0);
-    relro[0]=item2["relro"].toString().split(" ").at(0)[0].toUpper();
+    QString relro = item2["relro"].toString().split(" ").at(0);
+    relro[0] = item2["relro"].toString().split(" ").at(0)[0].toUpper();
     this->ui->relroEdit->setText(relro);
 
     this->ui->baddrEdit->setText(QString::number(item2["baddr"].toDouble()));

--- a/src/widgets/functionswidget.cpp
+++ b/src/widgets/functionswidget.cpp
@@ -509,7 +509,7 @@ void FunctionsWidget::on_action_References_triggered()
     QTreeView *treeView = getCurrentTreeView();
     FunctionDescription function = treeView->selectionModel()->currentIndex().data(FunctionModel::FunctionDescriptionRole).value<FunctionDescription>();
     XrefsDialog *x = new XrefsDialog(this->main, this);
-    x->fillRefsForFunction(function.offset, function.name);
+    x->fillRefsForAddress(function.offset, function.name, true);
     x->exec();
 }
 

--- a/src/widgets/memorywidget.cpp
+++ b/src/widgets/memorywidget.cpp
@@ -1403,7 +1403,7 @@ void MemoryWidget::on_codeCombo_2_currentTextChanged(const QString &arg1)
 void MemoryWidget::get_refs_data(RVA addr)
 {
     // refs = calls q hace esa funcion
-    QList<XrefDescription> refs = main->core->getXRefs(addr, false, "C");
+    QList<XrefDescription> refs = main->core->getXRefs(addr, false);
 
     // xrefs = calls a esa funcion
     QList<XrefDescription> xrefs = main->core->getXRefs(addr, true);

--- a/src/widgets/memorywidget.cpp
+++ b/src/widgets/memorywidget.cpp
@@ -1403,10 +1403,10 @@ void MemoryWidget::on_codeCombo_2_currentTextChanged(const QString &arg1)
 void MemoryWidget::get_refs_data(RVA addr)
 {
     // refs = calls q hace esa funcion
-    QList<XrefDescription> refs = main->core->getXRefs(addr, false);
+    QList<XrefDescription> refs = main->core->getXRefs(addr, false, false);
 
     // xrefs = calls a esa funcion
-    QList<XrefDescription> xrefs = main->core->getXRefs(addr, true);
+    QList<XrefDescription> xrefs = main->core->getXRefs(addr, true, false);
 
     // Data for the disasm side graph
     QList<int> data;
@@ -1837,14 +1837,9 @@ void MemoryWidget::on_actionXRefs_triggered()
     QString ele = lastline.split(" ", QString::SkipEmptyParts)[0];
     if (ele.contains("0x"))
     {
-        // Get function for clicked offset
-        RAnalFunction *fcn = this->main->core->functionAt(ele.toLongLong(0, 16));
-        if (!fcn)
-        {
-            return;
-        }
+        RVA addr = ele.toLongLong(0, 16);
         XrefsDialog *x = new XrefsDialog(this->main, this);
-        x->fillRefsForFunction(fcn->addr, QString::fromUtf8(fcn->name));
+        x->fillRefsForAddress(addr, RAddressString(addr), false);
         x->exec();
     }
 }

--- a/src/widgets/memorywidget.h
+++ b/src/widgets/memorywidget.h
@@ -158,8 +158,9 @@ private slots:
     void hexScrolled();
     QList<QString> get_hexdump(const QString &offset);
 
+    void showXrefsDialog();
     //void showDisas();
-    void showHexdump();
+    //void showHexdump();
     //void showGraph();
     void cycleViews();
     void on_xreFromTreeWidget_2_itemDoubleClicked(QTreeWidgetItem *item, int column);


### PR DESCRIPTION
These are some more changes for xrefs.
- I removed the filter for code-only xrefs, because I didn't see the sense of it. Data xrefs can be just as important.
- I made the xrefs in the sidebar and in the dialog when opened from the MemoryWidget specific to the current address, not the whole function. xrefs for the whole function can still be accessed from the context menu in the FunctionsWidget. @hteso I know you wanted to postpone this, but I just did it now because it was really easy to do and it can be confusing to always have all xrefs of the function otherwise. If you really, really don't want it, you could leave out that commit.
- X shortcut in MemoryWidget now shows the XrefsDialog instead of switching to Hexdump. Pressing space now switches between Disassembly, Graph and Hexdump instead of just Disassembly and Graph.

resolves #74