### PR TITLE
Add flag in disassembly context menu, changes in disassembly refreshing

### DIFF
--- a/src/dialogs/commentsdialog.ui
+++ b/src/dialogs/commentsdialog.ui
@@ -7,11 +7,11 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>61</height>
+    <height>75</height>
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Dialog</string>
+   <string>Comment</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <property name="spacing">

--- a/src/dialogs/flagdialog.cpp
+++ b/src/dialogs/flagdialog.cpp
@@ -3,8 +3,8 @@
 #include "flagdialog.h"
 
 FlagDialog::FlagDialog(IaitoRCore *core, RVA offset, QWidget *parent) :
-        QDialog(parent),
-        ui(new Ui::FlagDialog)
+    QDialog(parent),
+    ui(new Ui::FlagDialog)
 {
     ui->setupUi(this);
     setWindowFlags(windowFlags() & (~Qt::WindowContextHelpButtonHint));

--- a/src/dialogs/flagdialog.cpp
+++ b/src/dialogs/flagdialog.cpp
@@ -11,6 +11,10 @@ FlagDialog::FlagDialog(IaitoRCore *core, RVA offset, QWidget *parent) :
 
     this->core = core;
     this->offset = offset;
+
+    auto size_validator = new QIntValidator(ui->sizeEdit);
+    size_validator->setBottom(1);
+    ui->sizeEdit->setValidator(size_validator);
 }
 
 FlagDialog::~FlagDialog()
@@ -21,7 +25,8 @@ FlagDialog::~FlagDialog()
 void FlagDialog::on_buttonBox_accepted()
 {
     QString name = ui->nameEdit->text();
-    core->cmd(QString("f %1 @ %2").arg(name).arg(offset));
+    RVA size = ui->sizeEdit->text().toULongLong();
+    core->addFlag(offset, name, size);
 }
 
 void FlagDialog::on_buttonBox_rejected()

--- a/src/dialogs/flagdialog.cpp
+++ b/src/dialogs/flagdialog.cpp
@@ -1,0 +1,30 @@
+
+#include "ui_flagdialog.h"
+#include "flagdialog.h"
+
+FlagDialog::FlagDialog(IaitoRCore *core, RVA offset, QWidget *parent) :
+        QDialog(parent),
+        ui(new Ui::FlagDialog)
+{
+    ui->setupUi(this);
+    setWindowFlags(windowFlags() & (~Qt::WindowContextHelpButtonHint));
+
+    this->core = core;
+    this->offset = offset;
+}
+
+FlagDialog::~FlagDialog()
+{
+    delete ui;
+}
+
+void FlagDialog::on_buttonBox_accepted()
+{
+    QString name = ui->nameEdit->text();
+    core->cmd(QString("f %1 @ %2").arg(name).arg(offset));
+}
+
+void FlagDialog::on_buttonBox_rejected()
+{
+    close();
+}

--- a/src/dialogs/flagdialog.h
+++ b/src/dialogs/flagdialog.h
@@ -11,7 +11,7 @@ namespace Ui
 
 class FlagDialog : public QDialog
 {
-Q_OBJECT
+    Q_OBJECT
 
 public:
     explicit FlagDialog(IaitoRCore *core, RVA offset, QWidget *parent = 0);

--- a/src/dialogs/flagdialog.h
+++ b/src/dialogs/flagdialog.h
@@ -1,0 +1,31 @@
+#ifndef FLAGDIALOG_H
+#define FLAGDIALOG_H
+
+#include <QDialog>
+#include <iaitorcore.h>
+
+namespace Ui
+{
+    class FlagDialog;
+}
+
+class FlagDialog : public QDialog
+{
+Q_OBJECT
+
+public:
+    explicit FlagDialog(IaitoRCore *core, RVA offset, QWidget *parent = 0);
+    ~FlagDialog();
+
+private slots:
+    void on_buttonBox_accepted();
+    void on_buttonBox_rejected();
+
+private:
+    Ui::FlagDialog *ui;
+
+    IaitoRCore *core;
+    RVA offset;
+};
+
+#endif // FLAGDIALOG_H

--- a/src/dialogs/flagdialog.ui
+++ b/src/dialogs/flagdialog.ui
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>FlagDialog</class>
+ <widget class="QDialog" name="FlagDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>452</width>
+    <height>121</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Add Flag</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QFormLayout" name="formLayout">
+     <property name="horizontalSpacing">
+      <number>12</number>
+     </property>
+     <item row="0" column="0">
+      <widget class="QLabel" name="label">
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>Flag:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLineEdit" name="nameEdit">
+       <property name="frame">
+        <bool>false</bool>
+       </property>
+       <property name="placeholderText">
+        <string notr="true"/>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="sizeEdit">
+       <property name="maximumSize">
+        <size>
+         <width>100</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>1</string>
+       </property>
+       <property name="frame">
+        <bool>false</bool>
+       </property>
+       <property name="placeholderText">
+        <string notr="true"/>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_2">
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>Size:</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>FlagDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>FlagDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/iaito.pro
+++ b/src/iaito.pro
@@ -66,7 +66,8 @@ SOURCES += \
     hexhighlighter.cpp \
     widgets/sectionsdock.cpp \
     widgets/consolewidget.cpp \
-    radarewebserver.cpp
+    radarewebserver.cpp \
+    dialogs/flagdialog.cpp
 
 HEADERS  += \
     mainwindow.h \
@@ -106,7 +107,8 @@ HEADERS  += \
     radarewebserver.h \
     settings.h \
     iaitorcore.h \
-    iaitordisasm.h
+    iaitordisasm.h \
+    dialogs/flagdialog.h
 
 FORMS    += \
     mainwindow.ui \
@@ -131,7 +133,8 @@ FORMS    += \
     widgets/dashboard.ui \
     dialogs/xrefsdialog.ui \
     widgets/sectionsdock.ui \
-    widgets/consolewidget.ui
+    widgets/consolewidget.ui \
+    dialogs/flagdialog.ui
 
 RESOURCES += \
     resources.qrc

--- a/src/iaitorcore.h
+++ b/src/iaitorcore.h
@@ -247,6 +247,7 @@ public:
     Sdb *db;
 
 signals:
+    // TODO: create a more sophisticated update-event system
     void functionRenamed(QString prev_name, QString new_name);
     void flagsChanged();
     void commentsChanged();

--- a/src/iaitorcore.h
+++ b/src/iaitorcore.h
@@ -163,6 +163,7 @@ public:
     ~IaitoRCore();
 
     RVA getOffset() const                           { return core_->offset; }
+    static QString sanitizeStringForCommand(QString s);
     int getCycloComplex(ut64 addr);
     int getFcnSize(ut64 addr);
     int fcnCyclomaticComplexity(ut64 addr);
@@ -236,6 +237,8 @@ public:
 
     QList<XrefDescription> getXRefs(RVA addr, bool to, bool whole_function, const QString &filterType = QString::null);
 
+    void addFlag(RVA offset, QString name, RVA size);
+
     RCoreLocked core() const;
 
     /* fields */
@@ -244,6 +247,7 @@ public:
 
 signals:
     void functionRenamed(QString prev_name, QString new_name);
+    void flagsChanged();
 
 public slots:
 

--- a/src/iaitorcore.h
+++ b/src/iaitorcore.h
@@ -46,6 +46,8 @@ public:
 
 typedef ut64 RVA;
 
+#define RVA_INVALID UT64_MAX
+
 inline QString RAddressString(RVA addr)
 {
     return QString::asprintf("%#010llx", addr);

--- a/src/iaitorcore.h
+++ b/src/iaitorcore.h
@@ -175,7 +175,6 @@ public:
     QJsonDocument cmdj(const QString &str);
     void renameFunction(QString prev_name, QString new_name);
     void setComment(RVA addr, QString cmt);
-    void setComment(QString addr, QString cmt);
     void delComment(ut64 addr);
     QMap<QString, QList<QList<QString>>> getNestedComments();
     void setOptions(QString key);
@@ -250,6 +249,7 @@ public:
 signals:
     void functionRenamed(QString prev_name, QString new_name);
     void flagsChanged();
+    void commentsChanged();
 
 public slots:
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -767,9 +767,10 @@ void MainWindow::seek(const RVA offset, const QString &name, bool raise_memory_d
     this->hexdumpTopOffset = 0;
     this->hexdumpBottomOffset = 0;
     core->seek(offset);
+    emit globalSeekTo(offset);
     setCursorAddress(offset);
 
-    refreshMem();
+    //refreshMem();
     this->memoryDock->disasTextEdit->setFocus();
 
     // Rise and shine baby!

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -80,6 +80,7 @@ public:
     void refreshOmniBar(const QStringList &flags);
 
 signals:
+    void globalSeekTo(RVA address);
     void cursorAddressChanged(RVA address);
 
 public slots:

--- a/src/qrcore.cpp
+++ b/src/qrcore.cpp
@@ -167,6 +167,12 @@ IaitoRCore::~IaitoRCore()
     r_cons_free();
 }
 
+QString IaitoRCore::sanitizeStringForCommand(QString s)
+{
+    static const QRegExp regexp(";|@");
+    return s.replace(regexp, "_");
+}
+
 QString IaitoRCore::cmd(const QString &str)
 {
     CORE_LOCK();
@@ -1125,4 +1131,11 @@ QList<XrefDescription> IaitoRCore::getXRefs(RVA addr, bool to, bool whole_functi
     }
 
     return ret;
+}
+
+void IaitoRCore::addFlag(RVA offset, QString name, RVA size)
+{
+    name = sanitizeStringForCommand(name);
+    cmd(QString("f %1 %2 @ %3").arg(name).arg(size).arg(offset));
+    emit flagsChanged();
 }

--- a/src/qrcore.cpp
+++ b/src/qrcore.cpp
@@ -331,13 +331,9 @@ void IaitoRCore::setComment(RVA addr, QString cmt)
 {
     //r_meta_add (core->anal, 'C', addr, 1, cmt.toUtf8());
     cmd("CC " + cmt + " @ " + QString::number(addr));
+    emit commentsChanged();
 }
 
-void IaitoRCore::setComment(QString addr, QString cmt)
-{
-    //r_meta_add (core->anal, 'C', addr, 1, cmt.toUtf8());
-    cmd("CC " + cmt + " @ " + addr);
-}
 
 void IaitoRCore::delComment(ut64 addr)
 {

--- a/src/widgets/commentswidget.cpp
+++ b/src/widgets/commentswidget.cpp
@@ -28,6 +28,8 @@ CommentsWidget::CommentsWidget(MainWindow *main, QWidget *parent) :
     connect(this, SIGNAL(customContextMenuRequested(const QPoint &)),
             this, SLOT(showTitleContextMenu(const QPoint &)));
 
+    connect(main->core, SIGNAL(commentsChanged()), this, SLOT(refreshTree()));
+
     // Hide the buttons frame
     ui->frame->hide();
 }

--- a/src/widgets/flagswidget.cpp
+++ b/src/widgets/flagswidget.cpp
@@ -140,6 +140,8 @@ FlagsWidget::FlagsWidget(MainWindow *main, QWidget *parent) :
     connect(ui->filterLineEdit, SIGNAL(textChanged(const QString &)), flags_proxy_model, SLOT(setFilterWildcard(const QString &)));
     ui->flagsTreeView->setModel(flags_proxy_model);
     ui->flagsTreeView->sortByColumn(FlagsModel::OFFSET, Qt::AscendingOrder);
+
+    connect(main->core, SIGNAL(flagsChanged()), this, SLOT(flagsChanged()));
 }
 
 FlagsWidget::~FlagsWidget()
@@ -170,6 +172,11 @@ void FlagsWidget::on_flagspaceCombo_currentTextChanged(const QString &arg1)
     IAITONOTUSED(arg1);
 
     refreshFlags();
+}
+
+void FlagsWidget::flagsChanged()
+{
+    refreshFlagspaces();
 }
 
 void FlagsWidget::refreshFlagspaces()

--- a/src/widgets/flagswidget.h
+++ b/src/widgets/flagswidget.h
@@ -70,6 +70,8 @@ private slots:
     void on_flagsTreeView_doubleClicked(const QModelIndex &index);
     void on_flagspaceCombo_currentTextChanged(const QString &arg1);
 
+    void flagsChanged();
+
 private:
     Ui::FlagsWidget *ui;
     MainWindow      *main;

--- a/src/widgets/memorywidget.cpp
+++ b/src/widgets/memorywidget.cpp
@@ -404,7 +404,7 @@ RVA MemoryWidget::readCurrentDisassemblyOffset()
     QString lastline = tc.selectedText();
     QStringList parts = lastline.split(" ", QString::SkipEmptyParts);
 
-    if(parts.isEmpty())
+    if (parts.isEmpty())
         return RVA_INVALID;
 
     QString ele = parts[0];
@@ -469,11 +469,11 @@ void MemoryWidget::replaceTextDisasm(QString txt)
 
 bool MemoryWidget::loadMoreDisassembly()
 {
-/*
-     * Add more disasm as the user scrolls
-     * Not working properly when scrolling upwards
-     * r2 doesn't handle properly 'pd-' for archs with variable instruction size
-     */
+    /*
+         * Add more disasm as the user scrolls
+         * Not working properly when scrolling upwards
+         * r2 doesn't handle properly 'pd-' for archs with variable instruction size
+         */
 
     // Disconnect scroll signals to add more content
     disconnect(this->disasTextEdit->verticalScrollBar(), SIGNAL(valueChanged(int)), this, SLOT(disasmScrolled()));
@@ -490,7 +490,7 @@ bool MemoryWidget::loadMoreDisassembly()
         tc.movePosition(QTextCursor::End);
         RVA offset = readCurrentDisassemblyOffset();
 
-        if(offset != RVA_INVALID)
+        if (offset != RVA_INVALID)
         {
             main->core->seek(offset);
             QString raw = this->main->core->cmd("pd 200");
@@ -594,9 +594,9 @@ void MemoryWidget::refreshDisasm()
 
     // load more disassembly if necessary
     static const int load_more_limit = 10; // limit passes, so it can't take forever
-    for(int load_more_i = 0; load_more_i < load_more_limit; load_more_i++)
+    for (int load_more_i = 0; load_more_i < load_more_limit; load_more_i++)
     {
-        if(!loadMoreDisassembly())
+        if (!loadMoreDisassembly())
             break;
         disasTextEdit->verticalScrollBar()->setValue(scroll_pos);
     }
@@ -1993,7 +1993,7 @@ void MemoryWidget::updateViews(RVA offset)
 
     QString cursor_addr_string = RAddressString(cursor_addr);
 
-    if(offset != RVA_INVALID)
+    if (offset != RVA_INVALID)
         next_disasm_top_offset = offset;
 
     if (index == 0)

--- a/src/widgets/memorywidget.cpp
+++ b/src/widgets/memorywidget.cpp
@@ -998,6 +998,7 @@ void MemoryWidget::showDisasContextMenu(const QPoint &pt)
         // Add menu actions
         menu->clear();
         menu->addAction(ui->actionDisasAdd_comment);
+        menu->addAction(ui->actionAddFlag);
         menu->addAction(ui->actionFunctionsRename);
         menu->addAction(ui->actionFunctionsUndefine);
         menu->addSeparator();
@@ -1259,6 +1260,37 @@ void MemoryWidget::on_actionSend_to_Notepad_triggered()
 }
 
 void MemoryWidget::on_actionDisasAdd_comment_triggered()
+{
+    // Get current offset
+    QTextCursor tc = this->disasTextEdit->textCursor();
+    tc.select(QTextCursor::LineUnderCursor);
+    QString lastline = tc.selectedText();
+    QString ele = lastline.split(" ", QString::SkipEmptyParts)[0];
+    if (ele.contains("0x"))
+    {
+        // Get function for clicked offset
+        RAnalFunction *fcn = this->main->core->functionAt(ele.toLongLong(0, 16));
+        CommentsDialog *c = new CommentsDialog(this);
+        if (c->exec())
+        {
+            // Get new function name
+            QString comment = c->getComment();
+            //this->main->add_debug_output("Comment: " + comment + " at: " + ele);
+            // Rename function in r2 core
+            this->main->core->setComment(ele, comment);
+            // Seek to new renamed function
+            if (fcn)
+            {
+                this->main->seek(fcn->name);
+            }
+            // TODO: Refresh functions tree widget
+        }
+    }
+    this->main->refreshComments();
+}
+
+
+void MemoryWidget::on_actionAddFlag_triggered()
 {
     // Get current offset
     QTextCursor tc = this->disasTextEdit->textCursor();

--- a/src/widgets/memorywidget.cpp
+++ b/src/widgets/memorywidget.cpp
@@ -190,6 +190,7 @@ MemoryWidget::MemoryWidget(MainWindow *main) :
     connect(ui->graphWebView->page(), SIGNAL(loadFinished(bool)), this, SLOT(frameLoadFinished(bool)));
 
     connect(main, SIGNAL(cursorAddressChanged(RVA)), this, SLOT(on_cursorAddressChanged(RVA)));
+    connect(main->core, SIGNAL(flagsChanged()), this, SLOT(updateViews()));
 
     fillPlugins();
 }

--- a/src/widgets/memorywidget.h
+++ b/src/widgets/memorywidget.h
@@ -66,7 +66,7 @@ public slots:
 
     void replaceTextDisasm(QString txt);
 
-    void refreshDisasm(const QString &offset = QString());
+    void refreshDisasm();
 
     void refreshHexdump(const QString &where = QString());
 
@@ -92,7 +92,7 @@ public slots:
 
     void frameLoadFinished(bool ok);
 
-    void updateViews();
+    void updateViews(RVA offset = RVA_INVALID);
 
 protected:
     void resizeEvent(QResizeEvent *event) override;
@@ -106,8 +106,8 @@ private:
     QString last_fcn;
 
     RVA disasm_top_offset;
+    RVA next_disasm_top_offset;
 
-    RVA last_disasm_fcn;
     RVA last_graph_fcn;
     RVA last_hexdump_fcn;
 

--- a/src/widgets/memorywidget.h
+++ b/src/widgets/memorywidget.h
@@ -105,6 +105,8 @@ private:
     ut64 hexdumpBottomOffset;
     QString last_fcn;
 
+    RVA disasm_top_offset;
+
     RVA last_disasm_fcn;
     RVA last_graph_fcn;
     RVA last_hexdump_fcn;
@@ -115,6 +117,7 @@ private:
     void setScrollMode();
 
 private slots:
+    void on_globalSeekTo(RVA addr);
     void on_cursorAddressChanged(RVA addr);
 
     void highlightCurrentLine();

--- a/src/widgets/memorywidget.h
+++ b/src/widgets/memorywidget.h
@@ -116,6 +116,8 @@ private:
 
     void setScrollMode();
 
+    bool loadMoreDisassembly();
+
 private slots:
     void on_globalSeekTo(RVA addr);
     void on_cursorAddressChanged(RVA addr);

--- a/src/widgets/memorywidget.h
+++ b/src/widgets/memorywidget.h
@@ -122,6 +122,7 @@ private slots:
     void highlightHexCurrentLine();
     void highlightPreviewCurrentLine();
     void highlightDecoCurrentLine();
+    RVA readCurrentDisassemblyOffset();
     void setFonts(QFont font);
 
     void highlightHexWords(const QString &str);

--- a/src/widgets/memorywidget.h
+++ b/src/widgets/memorywidget.h
@@ -138,6 +138,7 @@ private slots:
     void showHexASCIIContextMenu(const QPoint &pt);
     void on_actionSend_to_Notepad_triggered();
     void on_actionDisasAdd_comment_triggered();
+    void on_actionAddFlag_triggered();
     void on_actionFunctionsRename_triggered();
     void on_actionDisas_ShowHideBytes_triggered();
 

--- a/src/widgets/memorywidget.ui
+++ b/src/widgets/memorywidget.ui
@@ -3036,6 +3036,11 @@ QToolTip {
     <string>Show stack pointer</string>
    </property>
   </action>
+  <action name="actionAddFlag">
+   <property name="text">
+    <string>Add flag</string>
+   </property>
+  </action>
  </widget>
  <customwidgets>
   <customwidget>
@@ -3050,7 +3055,7 @@ QToolTip {
  <connections/>
  <buttongroups>
   <buttongroup name="buttonGroup_3"/>
-  <buttongroup name="buttonGroup"/>
   <buttongroup name="buttonGroup_2"/>
+  <buttongroup name="buttonGroup"/>
  </buttongroups>
 </ui>


### PR DESCRIPTION
Fixes #69 

If you add a flag inside the disassembly view, you should see the change in the code right away. That's why I also changed a lot in the refreshing functionality of the MemoryWidget, so the current scroll and cursor position do not get lost.

The same goes for adding comments. I fixed that too. #194 